### PR TITLE
feat(core-service): add MongoDB review history logging

### DIFF
--- a/core-service/.env.example
+++ b/core-service/.env.example
@@ -1,10 +1,11 @@
-# ─────────────────────────────────────── Database ──────────────────────────────────────
+# ─────────────────────────────────────── Database ───────────────────────────────────────
 POSTGRES_DB="Name of the PostgreSQL database. e.g. core_db"
 POSTGRES_USER="# PostgreSQL role used by the service to connect. e.g. core_user"
 POSTGRES_HOST="# Hostname or IP where PostgreSQL is running (use 'core_database' when in Docker)"
 POSTGRES_PASSWORD="Password for the PostgreSQL role above. e.g. password"
 POSTGRES_PORT="Port PostgreSQL listens on. e.g. 5432"
-
+MONGO_URL="MongoDB connection string. e.g. mongodb://localhost:27017"
+MONGO_DB="Name of the MongoDB database. e.g. core_db"
 # ───────────────────────────────────────── API ─────────────────────────────────────────
 DEBUG="Set to true to enable the interactive docs at /docs (disable in production)"
 DEEPL_API_KEY=your_deepl_api_key_here

--- a/core-service/app/core/config.py
+++ b/core-service/app/core/config.py
@@ -1,24 +1,22 @@
 from pathlib import Path
 from functools import lru_cache
-
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=PROJECT_ROOT / '.env',
         extra='ignore'
     )
-
     postgres_db: str
     postgres_user: str
     postgres_host: str
     postgres_password: str
     postgres_port: int
     debug: bool
+    mongo_url: str
+    mongo_db: str
 
     @property
     def database_url(self) -> str:
@@ -26,7 +24,6 @@ class Settings(BaseSettings):
             f"postgresql://{self.postgres_user}:{self.postgres_password}"
             f"@{self.postgres_host}:{self.postgres_port}/{self.postgres_db}"
         )
-
 
 @lru_cache
 def get_settings() -> Settings:

--- a/core-service/app/core/dependencies.py
+++ b/core-service/app/core/dependencies.py
@@ -1,6 +1,7 @@
 from typing import Generator
 from fastapi import Request
 from sqlalchemy.orm import Session
+from motor.motor_asyncio import AsyncIOMotorDatabase
 
 
 def get_db(request: Request) -> Generator[Session, None, None]:
@@ -9,3 +10,7 @@ def get_db(request: Request) -> Generator[Session, None, None]:
         yield db
     finally:
         db.close()
+
+
+def get_mongo_db(request: Request) -> AsyncIOMotorDatabase:
+    return request.app.state.mongo_db

--- a/core-service/app/main.py
+++ b/core-service/app/main.py
@@ -1,41 +1,40 @@
 from contextlib import asynccontextmanager
-
 from fastapi import FastAPI
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from motor.motor_asyncio import AsyncIOMotorClient
 import app.models
-
 from app.routes import phrases
 from app.core.config import get_settings
 from app.models import phrase
 from app.models import language
 from app.routes import translate
+from app.routes import review_history
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     settings = get_settings()
+    # PostgreSQL
     engine = create_engine(settings.database_url)
     app.state.session_factory = sessionmaker(bind=engine, autoflush=False)
-
+    # MongoDB
+    client = AsyncIOMotorClient(settings.mongo_url)
+    app.state.mongo_db = client[settings.mongo_db]
     yield
-
     engine.dispose()
-
+    client.close()
 
 def get_app() -> FastAPI:
     settings = get_settings()
-
     app = FastAPI(
         title='Core service!:)',
         lifespan=lifespan,
         docs_url='/docs' if settings.debug else None
     )
-
     # ------------- Routers -------------
     app.include_router(phrases.router)
     app.include_router(translate.router)
-
+    app.include_router(review_history.router)
     return app
-
 
 app = get_app()

--- a/core-service/app/models/review_history.py
+++ b/core-service/app/models/review_history.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timezone
+from bson import ObjectId
+from pydantic import BaseModel, Field
+
+
+class ReviewHistoryDocument(BaseModel):
+    """MongoDB document representing a single flashcard review event."""
+    id: ObjectId = Field(default_factory=ObjectId, alias="_id")
+    user_id: int = Field(comment="User who performed the review; references auth-service")
+    phrase_id: int = Field(comment="Phrase reviewed; references PostgreSQL phrases table")
+    grade: int = Field(comment="SM-2 grade given by the user (0-5)")
+    easiness_factor: float = Field(comment="E-factor after this review")
+    interval_days: int = Field(comment="Interval in days until next review")
+    reviewed_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    model_config = {"arbitrary_types_allowed": True}

--- a/core-service/app/routes/review_history.py
+++ b/core-service/app/routes/review_history.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, status
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from app.core.dependencies import get_mongo_db
+from app.schemas.review_history import ReviewHistoryCreate, ReviewHistoryResponse
+from app.services.review_history_service import ReviewHistoryService
+
+router = APIRouter(prefix='/review-history', tags=['review-history'])
+
+
+def serialize(doc: dict) -> dict:
+    """Convert ObjectId to str for Pydantic serialization."""
+    doc['id'] = str(doc.pop('_id'))
+    return doc
+
+
+@router.post('/', response_model=ReviewHistoryResponse, status_code=status.HTTP_201_CREATED)
+async def log_review(body: ReviewHistoryCreate, db: AsyncIOMotorDatabase = Depends(get_mongo_db)):
+    service = ReviewHistoryService(db)
+    return serialize(await service.log_review(body))
+
+
+@router.get('/user/{user_id}', response_model=list[ReviewHistoryResponse])
+async def get_history_by_user(user_id: int, db: AsyncIOMotorDatabase = Depends(get_mongo_db)):
+    service = ReviewHistoryService(db)
+    history = await service.get_history_by_user(user_id)
+    return [serialize(h) for h in history]
+
+
+@router.get('/phrase/{phrase_id}', response_model=list[ReviewHistoryResponse])
+async def get_history_by_phrase(phrase_id: int, db: AsyncIOMotorDatabase = Depends(get_mongo_db)):
+    service = ReviewHistoryService(db)
+    history = await service.get_history_by_phrase(phrase_id)
+    return [serialize(h) for h in history]

--- a/core-service/app/schemas/review_history.py
+++ b/core-service/app/schemas/review_history.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from pydantic import BaseModel, ConfigDict
+
+
+class ReviewHistoryCreate(BaseModel):
+    user_id: int
+    phrase_id: int
+    grade: int
+    easiness_factor: float
+    interval_days: int
+
+
+class ReviewHistoryResponse(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    id: str
+    user_id: int
+    phrase_id: int
+    grade: int
+    easiness_factor: float
+    interval_days: int
+    reviewed_at: datetime

--- a/core-service/app/services/review_history_service.py
+++ b/core-service/app/services/review_history_service.py
@@ -1,0 +1,22 @@
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from app.models.review_history import ReviewHistoryDocument
+from app.schemas.review_history import ReviewHistoryCreate
+
+
+class ReviewHistoryService:
+    def __init__(self, db: AsyncIOMotorDatabase):
+        self.db = db
+
+    async def log_review(self, data: ReviewHistoryCreate) -> dict:
+        doc = ReviewHistoryDocument(**data.model_dump())
+        document = doc.model_dump(by_alias=True)
+        await self.db.review_history.insert_one(document)
+        return document
+
+    async def get_history_by_user(self, user_id: int) -> list[dict]:
+        cursor = self.db.review_history.find({"user_id": user_id})
+        return await cursor.to_list(length=100)
+
+    async def get_history_by_phrase(self, phrase_id: int) -> list[dict]:
+        cursor = self.db.review_history.find({"phrase_id": phrase_id})
+        return await cursor.to_list(length=100)

--- a/core-service/docker-compose.yml
+++ b/core-service/docker-compose.yml
@@ -1,5 +1,4 @@
 services:
-
   core_database:
     container_name: core_database
     image: postgres:16
@@ -10,6 +9,20 @@ services:
       - core_service_database:/var/lib/postgresql/data
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB']
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+
+  core_mongo:
+    container_name: core_mongo
+    image: mongo:7
+    ports:
+      - "27018:27017"
+    volumes:
+      - core_mongo_database:/data/db
+    healthcheck:
+      test: ['CMD', 'mongosh', '--eval', 'db.adminCommand("ping")']
       interval: 5s
       timeout: 3s
       retries: 10
@@ -33,11 +46,15 @@ services:
     env_file: .env
     environment:
       POSTGRES_HOST: core_database
+      MONGO_URL: mongodb://core_mongo:27017
     ports:
       - "8000:8000"
     depends_on:
       core_database:
         condition: service_healthy
+      core_mongo:
+        condition: service_healthy
 
 volumes:
   core_service_database:
+  core_mongo_database:

--- a/core-service/pyproject.toml
+++ b/core-service/pyproject.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 description = "Core microservice"
 readme = "README.md"
 requires-python = ">=3.13"
-
 dependencies = [
     "alembic>=1.18.4",
     "fastapi[standard]>=0.135.1",
+    "motor>=3.6.0",
     "psycopg2>=2.9.11",
     "pydantic-settings>=2.13.1",
     "sqlalchemy>=2.0.48",


### PR DESCRIPTION
## Changes
- Added MongoDB connection to Core Service via Motor (async driver)
- Added `ReviewHistoryDocument` model for MongoDB
- Added `ReviewHistoryService` with logging and querying by user/phrase
- Added `/review-history` endpoints (POST, GET by user, GET by phrase)
- Updated `config.py` with `mongo_url` and `mongo_db` settings
- Updated `dependencies.py` with `get_mongo_db` dependency
- Updated `docker-compose.yml` with `core_mongo` container
- Updated `.env.example` with MongoDB variables

## Testing
- Tested via `/docs` Swagger UI
- POST `/review-history/` logs a review event to MongoDB
- GET `/review-history/user/{user_id}` returns history filtered by user
- GET `/review-history/phrase/{phrase_id}` returns history filtered by phrase

Closes #37