### PR TITLE
feat: integrate user registration and existence check via GraphQL

### DIFF
--- a/auth-service/app/core/config.py
+++ b/auth-service/app/core/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
 
     debug: bool = False
     cors_origins: list[str] | None
+    CORS_ORIGINS: str
 
     @field_validator("cors_origins", mode='before')
     @classmethod

--- a/auth-service/app/main.py
+++ b/auth-service/app/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 
-from app.routes import users, gql_users
+from app.routes import gql_users
 from app.core.config import get_settings
 
 
@@ -30,14 +30,14 @@ def get_app() -> FastAPI:
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=settings.allowed_origins,
+        allow_origins=[settings.CORS_ORIGINS],
         allow_credentials=True,
         allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
         allow_headers=["Authorization", "Content-Type", "X-User-Sub"],
     )
 
     # -------------------------- Routers --------------------------
-    app.include_router(users.router)
+    #app.include_router(users.router)
     app.include_router(gql_users.graphql_app, prefix='/graphql')  # Montamos el router de GraphQL
 
     return app

--- a/auth-service/app/routes/gql_users.py
+++ b/auth-service/app/routes/gql_users.py
@@ -4,12 +4,13 @@ from strawberry.fastapi import GraphQLRouter
 from typing import Optional
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import select, update, func
 from sqlalchemy.orm import selectinload
-from app.types.gql_users import GraphQLUser, GraphQLLanguage
-from app.models.user import User
-from app.core.dependencies import get_db, get_current_user_sub
 
+from app.types.gql_users import GraphQLUser, GraphQLLanguage, CreateUserInput
+from app.models.user import User
+from app.models.language import Language
+from app.core.dependencies import get_db, get_current_user_sub
 
 
 @strawberry.type
@@ -19,7 +20,6 @@ class Query:
         db: AsyncSession = info.context["db"]
         auth0_sub: str = info.context["auth0_sub"]
 
-        # 2. Tu consulta EXACTA de SQLAlchemy (la misma que usaste en register)
         user = await db.scalar(
             select(User)
             .where(User.auth0_id == auth0_sub)
@@ -32,29 +32,126 @@ class Query:
         if not user:
             return None
 
-        # 3. Mapeamos el modelo de SQLAlchemy al tipo de GraphQL
         return GraphQLUser(
+            id=user.id,
             auth0_id=user.auth0_id,
             email=user.email,
             username=user.username,
             timezone=user.timezone,
             native_language=GraphQLLanguage(id=user.native_language.id, name=user.native_language.name),
-            learning_language=GraphQLLanguage(id=user.learning_language.id, name=user.learning_language.name)
+            learning_language=GraphQLLanguage(id=user.learning_language.id, name=user.learning_language.name),
+            accumulated_points=user.accumulated_points,
+            last_login_at=user.last_login_at,
         )
 
-# ==========================================
-# 3. EL PUENTE (Inyección de Dependencias)
-# ==========================================
+    @strawberry.field
+    async def user_exists(self, info: Info) -> Optional[GraphQLUser]:
+        db: AsyncSession = info.context["db"]
+        auth0_sub: str = info.context["auth0_sub"]
+
+        user = await db.scalar(
+            select(User)
+            .where(User.auth0_id == auth0_sub)
+            .options(
+                selectinload(User.native_language),
+                selectinload(User.learning_language),
+            )
+        )
+
+        if user is None:
+            return None
+
+        result = GraphQLUser(
+            id=user.id,
+            auth0_id=user.auth0_id,
+            email=user.email,
+            username=user.username,
+            timezone=user.timezone,
+            native_language=GraphQLLanguage(id=user.native_language.id, name=user.native_language.name),
+            learning_language=GraphQLLanguage(id=user.learning_language.id, name=user.learning_language.name),
+            accumulated_points=user.accumulated_points,
+            last_login_at=user.last_login_at,
+        )
+
+        await db.execute(
+            update(User)
+            .where(User.auth0_id == auth0_sub)
+            .values(last_login_at=func.now())
+        )
+        await db.commit()
+
+        return result
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    async def register_user(self, input: CreateUserInput, info: Info) -> GraphQLUser:
+        db: AsyncSession = info.context["db"]
+        auth0_sub: str = info.context["auth0_sub"]
+
+        existing = await db.scalar(
+            select(User).where(User.auth0_id == auth0_sub)
+        )
+        if existing:
+            raise ValueError("User already exists")
+
+        native_language_id = await db.scalar(
+            select(Language.id).where(Language.name == input.native_language)
+        )
+        if native_language_id is None:
+            raise ValueError(f"Unknown language: {input.native_language}")
+
+        learning_language_id = await db.scalar(
+            select(Language.id).where(Language.name == input.learning_language)
+        )
+        if learning_language_id is None:
+            raise ValueError(f"Unknown language: {input.learning_language}")
+
+        user = User(
+            auth0_id=auth0_sub,
+            native_language_id=native_language_id,
+            learning_language_id=learning_language_id,
+            email=input.email,
+            username=input.username,
+            timezone=input.timezone,
+            last_login_at=func.now(),
+        )
+        db.add(user)
+        await db.commit()
+
+        user = await db.scalar(
+            select(User)
+            .where(User.auth0_id == auth0_sub)
+            .options(
+                selectinload(User.native_language),
+                selectinload(User.learning_language),
+            )
+            .execution_options(populate_existing=True)
+        )
+
+        return GraphQLUser(
+            id=user.id,
+            auth0_id=user.auth0_id,
+            email=user.email,
+            username=user.username,
+            timezone=user.timezone,
+            native_language=GraphQLLanguage(id=user.native_language.id, name=user.native_language.name),
+            learning_language=GraphQLLanguage(id=user.learning_language.id, name=user.learning_language.name),
+            accumulated_points=user.accumulated_points,
+            last_login_at=user.last_login_at,
+        )
+
+
 async def get_graphql_context(
     auth0_sub: str = Depends(get_current_user_sub),
     db: AsyncSession = Depends(get_db)
 ):
-    #Esto inyecta tus dependencias de FastAPI directo en el 'info.context' de GraphQL
     return {
         "auth0_sub": auth0_sub,
         "db": db
     }
 
-# Creamos el router final
-schema = strawberry.Schema(query=Query)
+
+schema = strawberry.Schema(query=Query, mutation=Mutation)
 graphql_app = GraphQLRouter(schema, context_getter=get_graphql_context)

--- a/auth-service/app/routes/users.py
+++ b/auth-service/app/routes/users.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import selectinload
+""" from sqlalchemy.orm import selectinload
 from sqlalchemy import select, func, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import APIRouter, Depends, HTTPException
@@ -98,3 +98,4 @@ async def register(
         .execution_options(populate_existing=True)
     )
     return UserResponse.from_db(user)
+ """

--- a/auth-service/app/schemas/users.py
+++ b/auth-service/app/schemas/users.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+""" from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
@@ -52,3 +52,4 @@ class UserResponse(BaseModel):
             accumulated_points=user.accumulated_points,
             last_login_at=user.last_login_at
         ))
+ """

--- a/auth-service/app/types/gql_users.py
+++ b/auth-service/app/types/gql_users.py
@@ -1,15 +1,30 @@
+from datetime import datetime
 import strawberry
+
 
 @strawberry.type
 class GraphQLLanguage:
     id: int
     name: str
 
+
 @strawberry.type
 class GraphQLUser:
+    id: int
     auth0_id: str
     email: str
     username: str
     timezone: str
     native_language: GraphQLLanguage
     learning_language: GraphQLLanguage
+    accumulated_points: int | None = None
+    last_login_at: datetime | None = None
+
+
+@strawberry.input
+class CreateUserInput:
+    email: str
+    username: str
+    timezone: str
+    native_language: str
+    learning_language: str

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,17 @@ services:
       timeout: 5s
       retries: 5
 
+  redis:
+    image: redis:7-alpine
+    container_name: redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
   # ─── DB MIGRATIONS / SEEDERS ───────────────────────────────────────────────
   auth_migration:
     container_name: auth_migration
@@ -165,8 +176,12 @@ services:
       LOCAL_DB_PASSWORD: password
       JPA_DDL_AUTO: update
       JPA_SHOW_SQL: "true"
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 
   # ─── FRONTEND WEB APP ───────────────────────────────────────────────────────
@@ -179,13 +194,13 @@ services:
     environment:
       SERVER_AUTH_URL: http://api-gateway:8080/api/auth
       SERVER_CORE_URL: http://api-gateway:8080/api/core
-      SERVER_GRAPHQL_URL: http://api-gateway:8080/api/core/graphql
+      SERVER_GRAPHQL_URL: http://api-gateway:8080/api/auth/graphql
       SERVER_FORUM_URL: http://api-gateway:8080/api/forum
       SERVER_GAME_URL: http://api-gateway:8080/api/game
-      SERVER_GAMIFICATION_URL: http://api-gateway:8080/api/game
+      SERVER_GAMIFICATION_URL: http://api-gateway:8080/api/gamification
     depends_on:
       - api-gateway
-
+      - redis
 volumes:
   postgres_data:
   forum_mongo_database:

--- a/web-app/parla/actions/auth/authActions.ts
+++ b/web-app/parla/actions/auth/authActions.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import authApi from "./authApi";
 import { auth0 } from "@/lib/auth0";
 
 export interface CreateUserPayload {
@@ -25,51 +24,101 @@ export interface UserData {
   last_login_at: string;
 }
 
+const AUTH_GRAPHQL_URL =
+  (process.env.SERVER_AUTH_URL ??
+    process.env.NEXT_PUBLIC_AUTH_URL ??
+    "http://localhost:8080/api/auth") + "/graphql";
+
+async function authGraphqlFetch(
+  query: string,
+  variables?: Record<string, unknown>,
+) {
+  const { token } = await auth0.getAccessToken();
+  const res = await fetch(AUTH_GRAPHQL_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ query, variables }),
+    cache: "no-store",
+  });
+  return res.json();
+}
+
 export async function registerUserAction(data: CreateUserPayload) {
   try {
-    const response = await authApi.post("users/register", data);
-
-    return {
-      success: true,
-      data: response.data,
-    };
-  } catch (error: any) {
-    console.error(
-      "Error during registration: ",
-      error.response?.data || error.message,
+    const result = await authGraphqlFetch(
+      `mutation RegisterUser($input: CreateUserInput!) {
+        registerUser(input: $input) {
+          id
+          auth0Id
+          email
+          username
+        }
+      }`,
+      {
+        input: {
+          email: data.email,
+          username: data.username,
+          timezone: data.timezone,
+          nativeLanguage: data.native_language,
+          learningLanguage: data.learning_language,
+        },
+      },
     );
 
-    if (error.response) {
-      const status = error.response.status;
-      const detail = error.response.data.detail;
-
-      if (status === 409)
+    if (result.errors) {
+      const msg: string = result.errors[0]?.message ?? "Unknown error";
+      if (msg.toLowerCase().includes("already exists"))
         return { success: false, error: "User already exists" };
-      if (status === 422) return { success: false, error: "Validation error" };
-
-      return { success: false, error: detail };
+      return { success: false, error: msg };
     }
+
+    return { success: true, data: result.data?.registerUser };
+  } catch (error: any) {
+    console.error("Error during registration:", error.message);
     return { success: false, error: "Server connection error" };
   }
 }
 
 export async function checkUserExistsAction() {
   try {
-    const response = await authApi.get("users/exists");
+    const result = await authGraphqlFetch(
+      `query UserExists {
+        userExists {
+          id
+          auth0Id
+          email
+          username
+          timezone
+          nativeLanguage { id name }
+          learningLanguage { id name }
+          accumulatedPoints
+          lastLoginAt
+        }
+      }`,
+    );
 
-    const responseData = response.data;
-
-    if (!responseData || responseData.data === null) {
+    if (result.errors || !result.data?.userExists) {
       return { exists: false, user: null };
     }
 
-    return { exists: true, user: responseData.data };
+    const u = result.data.userExists;
+    return {
+      exists: true,
+      user: {
+        id: u.id,
+        email: u.email,
+        username: u.username,
+        native_language: u.nativeLanguage,
+        learning_language: u.learningLanguage,
+        accumulated_points: u.accumulatedPoints,
+        last_login_at: u.lastLoginAt,
+      } as UserData,
+    };
   } catch (error: any) {
-    console.error(
-      "Error checking user existence: ",
-      error.response?.data || error.message,
-    );
-
+    console.error("Error checking user existence:", error.message);
     return { exists: false, user: null };
   }
 }

--- a/web-app/parla/app/onboarding/page.tsx
+++ b/web-app/parla/app/onboarding/page.tsx
@@ -59,6 +59,8 @@ export default function OnboardingPage() {
     resolver: zodResolver(onboardingSchema),
     defaultValues: {
       username: "",
+      native_language: "Spanish",
+      learning_language: "English",
       // Puedes dejar estos vacíos para obligar al usuario a elegir
     },
   });

--- a/web-app/parla/lib/apollo-client.ts
+++ b/web-app/parla/lib/apollo-client.ts
@@ -20,8 +20,8 @@ export const { getClient, query, PreloadQuery } = registerApolloClient(() => {
     cache: new InMemoryCache(),
     link: new HttpLink({
       uri: typeof window === 'undefined' 
-        ? (process.env.SERVER_GRAPHQL_URL ?? process.env.NEXT_PUBLIC_GRAPHQL_URL ?? "http://localhost:8080/api/core/graphql")
-        : (process.env.NEXT_PUBLIC_GRAPHQL_URL ?? "http://localhost:8080/api/core/graphql"),
+        ? (process.env.SERVER_GRAPHQL_URL ?? process.env.NEXT_PUBLIC_GRAPHQL_URL ?? "http://localhost:8080/api/auth/graphql")
+        : (process.env.NEXT_PUBLIC_GRAPHQL_URL ?? "http://localhost:8080/api/auth/graphql"),
       // El fetch nativo de Node.js / Next.js se usa por defecto en el servidor.
       fetchOptions: { cache: "no-store" },
     }),


### PR DESCRIPTION
This pull request introduces a major refactor to the authentication service and onboarding flow, migrating user registration and existence checks from REST endpoints to GraphQL mutations and queries. It also updates the Docker and frontend configuration to support these changes, including adding a Redis service and correcting various environment variables.

**Backend GraphQL migration and enhancements:**

* The `users` REST endpoints and Pydantic schemas are commented out in favor of new GraphQL resolvers for user registration and existence checks. The new `gql_users.py` file defines `userExists` (query) and `registerUser` (mutation) using Strawberry, with proper SQLAlchemy integration and validation. (`[[1]](diffhunk://#diff-4c6af42379a66264bedb738524b27891e97907aa7abcd9783a9aecca7a2f859bL7-L22)`, `[[2]](diffhunk://#diff-4c6af42379a66264bedb738524b27891e97907aa7abcd9783a9aecca7a2f859bL35-R156)`, `[[3]](diffhunk://#diff-09cd59510d2178029a15d20bef619cb14ca18dda6ad60c38fd5ced02ee90ba4aL1-R1)`, `[[4]](diffhunk://#diff-09cd59510d2178029a15d20bef619cb14ca18dda6ad60c38fd5ced02ee90ba4aR101)`, `[[5]](diffhunk://#diff-a5fb32d34b272dca1cd6e02ba1e7b0ce420de7f8d2c4e4d6ec49f768799a72deL1-R1)`, `[[6]](diffhunk://#diff-a5fb32d34b272dca1cd6e02ba1e7b0ce420de7f8d2c4e4d6ec49f768799a72deR55)`, `[[7]](diffhunk://#diff-7dd1039ce8dc9b38fc9242455c0eac82a9ab26723c810d6c5cf2470cc5510c2fR1-R30)`)

* The GraphQL user types are extended to include more fields (`id`, `accumulated_points`, `last_login_at`), and a new input type (`CreateUserInput`) is introduced for registration. (`[auth-service/app/types/gql_users.pyR1-R30](diffhunk://#diff-7dd1039ce8dc9b38fc9242455c0eac82a9ab26723c810d6c5cf2470cc5510c2fR1-R30)`)

**Frontend migration to GraphQL:**

* The `registerUserAction` and `checkUserExistsAction` functions in the frontend now use GraphQL fetches instead of REST calls, updating the payloads and response handling accordingly. (`[[1]](diffhunk://#diff-3f5cbb62d6ba1f2487fec970bfc0465c866d8ce0c6f23a0aa62eb981dc9eb068L3)`, `[[2]](diffhunk://#diff-3f5cbb62d6ba1f2487fec970bfc0465c866d8ce0c6f23a0aa62eb981dc9eb068R27-R121)`)

* The Apollo client and environment variables are updated to point to the new `/api/auth/graphql` endpoint instead of the previous `/api/core/graphql`. (`[web-app/parla/lib/apollo-client.tsL23-R24](diffhunk://#diff-c247f367510157fadc9be48b01e17b6e9c7f4daa0d2faef0c0cf0b42edc26fa9L23-R24)`)

**Infrastructure and configuration updates:**

* A Redis service is added to `docker-compose.yml`, and relevant environment variables are set for the backend to use Redis. Dependencies are updated so that services wait for Redis to be healthy. (`[[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R33-R43)`, `[[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R179-R185)`)

* The `SERVER_GRAPHQL_URL` and `SERVER_GAMIFICATION_URL` environment variables are corrected for the web app and backend. (`[docker-compose.ymlL182-R203](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L182-R203)`)

**Other changes:**

* Default onboarding form values are set for `native_language` and `learning_language` to streamline the user experience. (`[web-app/parla/app/onboarding/page.tsxR62-R63](diffhunk://#diff-44bf967d65e11c63727c1c5840ef833a2b20a0e3a073cd41b0ae6845401f0605R62-R63)`)

* The CORS configuration is refactored for clarity, and unused imports and routers are removed or commented out. (`[[1]](diffhunk://#diff-572b1371c51e37fc170eda68c91e2ab872d74b67011e9d0896dc0babb66fbafcR25)`, `[[2]](diffhunk://#diff-aacd6171b28be809f0bf02b759a8bd5861087b2149f71560e27f909426ad269dL7-R7)`, `[[3]](diffhunk://#diff-aacd6171b28be809f0bf02b759a8bd5861087b2149f71560e27f909426ad269dL33-R40)`)

---

**Backend GraphQL migration and enhancements:**
- Migrated user registration and existence checks from REST endpoints to GraphQL queries and mutations in `gql_users.py`, deprecating the old REST routes. (`[[1]](diffhunk://#diff-4c6af42379a66264bedb738524b27891e97907aa7abcd9783a9aecca7a2f859bL7-L22)`, `[[2]](diffhunk://#diff-4c6af42379a66264bedb738524b27891e97907aa7abcd9783a9aecca7a2f859bL35-R156)`, `[[3]](diffhunk://#diff-09cd59510d2178029a15d20bef619cb14ca18dda6ad60c38fd5ced02ee90ba4aL1-R1)`, `[[4]](diffhunk://#diff-09cd59510d2178029a15d20bef619cb14ca18dda6ad60c38fd5ced02ee90ba4aR101)`, `[[5]](diffhunk://#diff-a5fb32d34b272dca1cd6e02ba1e7b0ce420de7f8d2c4e4d6ec49f768799a72deL1-R1)`, `[[6]](diffhunk://#diff-a5fb32d34b272dca1cd6e02ba1e7b0ce420de7f8d2c4e4d6ec49f768799a72deR55)`)
- Extended GraphQL user types and added `CreateUserInput` for user registration. (`[auth-service/app/types/gql_users.pyR1-R30](diffhunk://#diff-7dd1039ce8dc9b38fc9242455c0eac82a9ab26723c810d6c5cf2470cc5510c2fR1-R30)`)

**Frontend migration to GraphQL:**
- Updated `registerUserAction` and `checkUserExistsAction` to use GraphQL endpoints, removing dependency on REST API. (`[[1]](diffhunk://#diff-3f5cbb62d6ba1f2487fec970bfc0465c866d8ce0c6f23a0aa62eb981dc9eb068L3)`, `[[2]](diffhunk://#diff-3f5cbb62d6ba1f2487fec970bfc0465c866d8ce0c6f23a0aa62eb981dc9eb068R27-R121)`)
- Updated Apollo client and environment variables to target `/api/auth/graphql`. (`[web-app/parla/lib/apollo-client.tsL23-R24](diffhunk://#diff-c247f367510157fadc9be48b01e17b6e9c7f4daa0d2faef0c0cf0b42edc26fa9L23-R24)`)

**Infrastructure and configuration:**
- Added Redis service to `docker-compose.yml` and updated backend environment variables and dependencies to use Redis. (`[[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R33-R43)`, `[[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R179-R185)`)
- Corrected environment variables for GraphQL and gamification service URLs. (`[docker-compose.ymlL182-R203](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L182-R203)`)

**User experience:**
- Set default onboarding form values for languages. (`[web-app/parla/app/onboarding/page.tsxR62-R63](diffhunk://#diff-44bf967d65e11c63727c1c5840ef833a2b20a0e3a073cd41b0ae6845401f0605R62-R63)`)

**Codebase cleanup:**
- Refactored CORS configuration and removed/commented out unused routers and imports. (`[[1]](diffhunk://#diff-572b1371c51e37fc170eda68c91e2ab872d74b67011e9d0896dc0babb66fbafcR25)`, `[[2]](diffhunk://#diff-aacd6171b28be809f0bf02b759a8bd5861087b2149f71560e27f909426ad269dL7-R7)`, `[[3]](diffhunk://#diff-aacd6171b28be809f0bf02b759a8bd5861087b2149f71560e27f909426ad269dL33-R40)`)