### PR TITLE
fix: update baseURL configuration in for forum API to prioritize envi…

### DIFF
--- a/web-app/parla/lib/forum/api.ts
+++ b/web-app/parla/lib/forum/api.ts
@@ -14,7 +14,10 @@ import type {
 } from "./types";
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_FORUM_URL || "http://localhost:8003",
+  baseURL:
+    process.env.SERVER_FORUM_URL ??
+    process.env.NEXT_PUBLIC_FORUM_URL ??
+    "http://localhost:8080/api/forum",
 });
 
 api.interceptors.request.use(async (config) => {


### PR DESCRIPTION
…ronment variables
This pull request updates the forum API configuration to improve environment variable handling and ensure the correct base URL is used for API requests.

API configuration improvements:

* The `baseURL` for the forum API in `forum/api.ts` now prioritizes `SERVER_FORUM_URL`, then `NEXT_PUBLIC_FORUM_URL`, and defaults to `"http://localhost:8080/api/forum"` if neither is set. This provides more flexibility and corrects the default port and path.