### PR TITLE
Refactor vocabulary and dictionary pages for user-specific language handling

### DIFF
--- a/web-app/parla/app/dictionary/page.tsx
+++ b/web-app/parla/app/dictionary/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useUser } from "@auth0/nextjs-auth0/client";
 import { ScrollReveal } from "@/components/core/ScrollReveal";
@@ -8,6 +8,7 @@ import { Search, Book, Plus, Loader2, RefreshCw } from "lucide-react";
 import HomeNavBar from "@/components/core/HomeNavBar";
 import { getInitials } from "@/lib/user-utils";
 import { useDictionary } from "@/contexts/DictionaryContext";
+import { useParlaUser } from "@/hooks/useParlaUser";
 import { DictionaryCard } from "@/components/dictionary/DictionaryCard";
 import { DictionaryStatsCards } from "@/components/dictionary/DictionaryStats";
 import { DictionaryFiltersPanel } from "@/components/dictionary/DictionaryFilters";
@@ -28,6 +29,8 @@ import {
 export default function DictionaryPage() {
   const router = useRouter();
   const { user, isLoading: isUserLoading } = useUser();
+  const { numericId, learningLanguageCode } = useParlaUser();
+  const hasAttemptedPopulation = useRef(false);
   const {
     words,
     isLoading,
@@ -83,14 +86,18 @@ export default function DictionaryPage() {
 
   // Auto-populate dictionary from phrases when user is authenticated
   useEffect(() => {
-    if (user && isInitialized && words.length === 0 && !isPopulating) {
-      // Get user ID from Auth0 user object
-      const userId = 1; // TODO: Extract from user.sub or user metadata
-      
-      console.log('🔄 Auto-populating dictionary from user phrases...');
-      populateFromPhrases(userId);
+    if (
+      user &&
+      isInitialized &&
+      numericId &&
+      words.length === 0 &&
+      !isPopulating &&
+      !hasAttemptedPopulation.current
+    ) {
+      hasAttemptedPopulation.current = true;
+      populateFromPhrases(numericId, learningLanguageCode ?? 'es');
     }
-  }, [user, isInitialized, words.length, isPopulating, populateFromPhrases]);
+  }, [user, isInitialized, numericId, learningLanguageCode, words.length, isPopulating, populateFromPhrases]);
 
   // Redirect if not logged in
   useEffect(() => {
@@ -100,10 +107,17 @@ export default function DictionaryPage() {
   }, [user, isUserLoading, router]);
 
   // Handlers
+  const langMap: Record<string, string> = {
+    en: "en-US", es: "es-ES", fr: "fr-FR", de: "de-DE",
+    it: "it-IT", pt: "pt-BR", ja: "ja-JP", zh: "zh-CN", ko: "ko-KR",
+    nl: "nl-NL", pl: "pl-PL", ru: "ru-RU", ar: "ar-SA",
+  };
+
   const handleSpeak = (text: string, wordId: string) => {
     if ("speechSynthesis" in window) {
+      const word = words.find((w) => w.id === wordId);
       const utterance = new SpeechSynthesisUtterance(text);
-      utterance.lang = "en-US";
+      utterance.lang = langMap[word?.language ?? "en"] ?? "en-US";
       setSpeakingWordId(wordId);
       window.speechSynthesis.speak(utterance);
       setTimeout(() => setSpeakingWordId(null), 2000);
@@ -125,9 +139,8 @@ export default function DictionaryPage() {
   };
 
   const handleRefreshDictionary = () => {
-    const userId = 1; // TODO: Extract from user.sub or user metadata
-    console.log('🔄 Manually refreshing dictionary from phrases...');
-    populateFromPhrases(userId);
+    if (!numericId) return;
+    populateFromPhrases(numericId, learningLanguageCode ?? 'es');
   };
 
   const handleAddWord = (wordData: {

--- a/web-app/parla/app/vocabulary/page.tsx
+++ b/web-app/parla/app/vocabulary/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { ScrollReveal } from "@/components/core/ScrollReveal";
 import { Search, Brain, Flame, BatteryWarning, Plus } from "lucide-react";
 import PhraseCard from "@/components/vocabulary/PhraseCard";
 import PhraseModal from "@/components/vocabulary/PhraseModal";
 import { useUser } from "@auth0/nextjs-auth0/client";
+import { useParlaUser } from "@/hooks/useParlaUser";
 import HomeNavBar from "@/components/core/HomeNavBar";
 import { getInitials } from "@/lib/user-utils";
 import { Phrase, PhraseCreate, PhraseUpdate } from "@/lib/types/phrases";
@@ -18,12 +19,14 @@ const FILTERS = ["Todos", "Recientes", "Necesitan Repaso", "Dominadas"];
 export default function VocabularioPage() {
   const router = useRouter();
   const { user, isLoading } = useUser();
+  const { numericId, nativeLanguageId, learningLanguageId } = useParlaUser();
   const [activeFilter, setActiveFilter] = useState("Todos");
   const [searchQuery, setSearchQuery] = useState("");
   const [phrases, setPhrases] = useState<Phrase[]>([]);
   const [isLoadingPhrases, setIsLoadingPhrases] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingPhrase, setEditingPhrase] = useState<Phrase | null>(null);
+  const [deletingPhraseId, setDeletingPhraseId] = useState<number | null>(null);
 
   useEffect(() => {
     if (!isLoading && !user) {
@@ -31,13 +34,7 @@ export default function VocabularioPage() {
     }
   }, [user, isLoading, router]);
 
-  useEffect(() => {
-    if (user) {
-      fetchPhrases();
-    }
-  }, [user]);
-
-  const fetchPhrases = async () => {
+  const fetchPhrases = useCallback(async () => {
     try {
       setIsLoadingPhrases(true);
       const data = await phrasesService.getAllPhrases();
@@ -48,7 +45,13 @@ export default function VocabularioPage() {
     } finally {
       setIsLoadingPhrases(false);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    if (user) {
+      fetchPhrases();
+    }
+  }, [user, fetchPhrases]);
 
   const handleCreatePhrase = async (data: PhraseCreate | PhraseUpdate) => {
     try {
@@ -75,11 +78,16 @@ export default function VocabularioPage() {
     }
   };
 
-  const handleDeletePhrase = async (phraseId: number) => {
-    if (!confirm("¿Estás seguro de que quieres eliminar esta frase?")) return;
+  const handleDeletePhrase = (phraseId: number) => {
+    setDeletingPhraseId(phraseId);
+  };
+
+  const confirmDeletePhrase = async () => {
+    if (!deletingPhraseId) return;
     try {
-      await phrasesService.deletePhrase(phraseId);
+      await phrasesService.deletePhrase(deletingPhraseId);
       toast.success("Frase eliminada exitosamente");
+      setDeletingPhraseId(null);
       await fetchPhrases();
     } catch (error) {
       console.error("Error deleting phrase:", error);
@@ -323,8 +331,34 @@ export default function VocabularioPage() {
         onClose={handleCloseModal}
         onSave={editingPhrase ? handleUpdatePhrase : handleCreatePhrase}
         phrase={editingPhrase}
-        userId={1}
+        userId={numericId ?? 1}
+        sourceLanguageId={nativeLanguageId ?? 1}
+        targetLanguageId={learningLanguageId ?? 2}
       />
+
+      {/* Confirm delete dialog */}
+      {deletingPhraseId !== null && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-3xl border-4 border-parla-dark shadow-[0_8px_0_0_var(--color-parla-dark)] max-w-sm w-full p-6 space-y-4">
+            <h2 className="font-brand text-2xl text-parla-dark">¿Eliminar frase?</h2>
+            <p className="font-bold text-parla-blue">Esta acción no se puede deshacer.</p>
+            <div className="flex gap-3 pt-2">
+              <button
+                onClick={() => setDeletingPhraseId(null)}
+                className="flex-1 py-3 px-6 rounded-xl border-2 border-parla-light text-parla-dark font-black hover:bg-parla-mist transition-colors"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={confirmDeletePhrase}
+                className="flex-1 py-3 px-6 rounded-xl bg-parla-red text-white font-black border-b-4 border-[#8C0327] hover:bg-[#a0032e] active:border-b-0 active:translate-y-1 transition-all"
+              >
+                Eliminar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web-app/parla/app/vocabulary/practice/page.tsx
+++ b/web-app/parla/app/vocabulary/practice/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useUser } from "@auth0/nextjs-auth0/client";
+import { useParlaUser } from "@/hooks/useParlaUser";
 import { ScrollReveal } from "@/components/core/ScrollReveal";
 import { Brain, ArrowLeft, RotateCcw, CheckCircle, Loader2, Trophy } from "lucide-react";
 import HomeNavBar from "@/components/core/HomeNavBar";
@@ -60,6 +61,7 @@ const QUALITY_OPTIONS = [
 export default function PracticePage() {
   const router = useRouter();
   const { user, isLoading: isUserLoading } = useUser();
+  const { numericId } = useParlaUser();
   const [duePhrases, setDuePhrases] = useState<Phrase[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isFlipped, setIsFlipped] = useState(false);
@@ -75,20 +77,13 @@ export default function PracticePage() {
     }
   }, [user, isUserLoading, router]);
 
-  useEffect(() => {
-    if (user) {
-      fetchDuePhrases();
-    }
-  }, [user]);
-
-  const fetchDuePhrases = async () => {
+  const fetchDuePhrases = useCallback(async () => {
+    if (!numericId) return;
     try {
       setIsLoading(true);
-      // TODO: Get actual user ID from Auth0 session - for now the backend extracts it from JWT
-      const userId = 1;
-      const data = await phrasesService.getDuePhrases(userId);
+      const data = await phrasesService.getDuePhrases(numericId);
       setDuePhrases(data);
-      
+
       if (data.length === 0) {
         toast.info("¡No tienes frases pendientes de repaso!");
       }
@@ -98,7 +93,13 @@ export default function PracticePage() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [numericId]);
+
+  useEffect(() => {
+    if (user) {
+      fetchDuePhrases();
+    }
+  }, [user, fetchDuePhrases]);
 
   const handleFlip = () => {
     if (!showRating) {
@@ -160,7 +161,7 @@ export default function PracticePage() {
     setShowRating(false);
     setSessionComplete(false);
     setReviewedCount(0);
-    fetchDuePhrases();
+    void fetchDuePhrases();
   };
 
   if (isUserLoading || isLoading) {

--- a/web-app/parla/components/vocabulary/PhraseModal.tsx
+++ b/web-app/parla/components/vocabulary/PhraseModal.tsx
@@ -10,9 +10,11 @@ interface PhraseModalProps {
   onSave: (data: PhraseCreate | PhraseUpdate) => Promise<void>;
   phrase?: Phrase | null;
   userId: number;
+  sourceLanguageId: number;
+  targetLanguageId: number;
 }
 
-export default function PhraseModal({ isOpen, onClose, onSave, phrase, userId }: PhraseModalProps) {
+export default function PhraseModal({ isOpen, onClose, onSave, phrase, userId, sourceLanguageId, targetLanguageId }: PhraseModalProps) {
   const [originalText, setOriginalText] = useState("");
   const [translatedText, setTranslatedText] = useState("");
   const [pronunciation, setPronunciation] = useState("");
@@ -45,8 +47,8 @@ export default function PhraseModal({ isOpen, onClose, onSave, phrase, userId }:
       } else {
         const createData: PhraseCreate = {
           user_id: userId,
-          source_language_id: 1,
-          target_language_id: 2,
+          source_language_id: sourceLanguageId,
+          target_language_id: targetLanguageId,
           original_text: originalText,
           translated_text: translatedText,
           pronunciation: pronunciation || null,

--- a/web-app/parla/contexts/DictionaryContext.tsx
+++ b/web-app/parla/contexts/DictionaryContext.tsx
@@ -11,7 +11,7 @@ interface DictionaryContextType {
   isPopulating: boolean;
   populationProgress: PopulationProgress | null;
   loadDictionary: () => Promise<void>;
-  populateFromPhrases: (userId: number) => Promise<void>;
+  populateFromPhrases: (userId: number, targetLanguage?: string) => Promise<void>;
   addWord: (word: DictionaryWord) => void;
   updateWord: (id: string, updates: Partial<DictionaryWord>) => void;
   deleteWord: (id: string) => void;
@@ -56,7 +56,7 @@ export function DictionaryProvider({ children }: { children: React.ReactNode }) 
 
   // Save to localStorage whenever words change
   useEffect(() => {
-    if (isInitialized && words.length >= 0) {
+    if (isInitialized) {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(words));
     }
   }, [words, isInitialized]);
@@ -97,7 +97,7 @@ export function DictionaryProvider({ children }: { children: React.ReactNode }) 
   }, []);
 
   // Populate dictionary from user's phrases
-  const populateFromPhrases = useCallback(async (userId: number) => {
+  const populateFromPhrases = useCallback(async (userId: number, targetLanguage?: string) => {
     setIsPopulating(true);
     setPopulationProgress(null);
 
@@ -105,7 +105,7 @@ export function DictionaryProvider({ children }: { children: React.ReactNode }) 
       const result = await populateDictionaryFromPhrases(userId, {
         filterStopWords: true,
         maxDefinitionsPerWord: 3,
-        targetLanguage: 'es',
+        targetLanguage: (targetLanguage ?? 'es') as import('@/lib/types/dictionary').Language,
         onProgress: (progress) => {
           setPopulationProgress(progress);
         },

--- a/web-app/parla/hooks/useParlaUser.ts
+++ b/web-app/parla/hooks/useParlaUser.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useUser } from "@auth0/nextjs-auth0/client";
+import { checkUserExistsAction } from "@/actions/auth/authActions";
+import type { Language } from "@/lib/types/dictionary";
+
+const LANG_NAME_TO_CODE: Record<string, Language> = {
+  Spanish: "es",
+  English: "en",
+  French: "fr",
+  German: "de",
+  Italian: "it",
+  Portuguese: "pt",
+  Dutch: "nl",
+  Polish: "pl",
+  Russian: "ru",
+  Japanese: "ja",
+  Chinese: "zh",
+  Korean: "ko",
+  Arabic: "ar",
+};
+
+interface ParlaUser {
+  numericId: number | null;
+  nativeLanguageId: number | null;
+  learningLanguageId: number | null;
+  learningLanguageCode: Language | null;
+  isLoading: boolean;
+}
+
+export function useParlaUser(): ParlaUser {
+  const { user, isLoading: isAuth0Loading } = useUser();
+  const [numericId, setNumericId] = useState<number | null>(null);
+  const [nativeLanguageId, setNativeLanguageId] = useState<number | null>(null);
+  const [learningLanguageId, setLearningLanguageId] = useState<number | null>(null);
+  const [learningLanguageCode, setLearningLanguageCode] = useState<Language | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (isAuth0Loading || !user) return;
+
+    checkUserExistsAction().then(({ exists, user: parlaUser }) => {
+      if (exists && parlaUser) {
+        setNumericId(parseInt(parlaUser.id));
+        setNativeLanguageId(parlaUser.native_language.id);
+        setLearningLanguageId(parlaUser.learning_language.id);
+        setLearningLanguageCode(
+          LANG_NAME_TO_CODE[parlaUser.learning_language.name] ?? "en"
+        );
+      }
+      setIsLoading(false);
+    });
+  }, [user, isAuth0Loading]);
+
+  return { numericId, nativeLanguageId, learningLanguageId, learningLanguageCode, isLoading };
+}

--- a/web-app/parla/pnpm-lock.yaml
+++ b/web-app/parla/pnpm-lock.yaml
@@ -113,16 +113,16 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.1.6
-        version: 16.1.6(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.35)
+        version: 29.7.0(@types/node@20.19.37)
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
       jest-mock-axios:
         specifier: ^4.7.3
-        version: 4.9.0(@types/node@20.19.35)
+        version: 4.9.0(@types/node@20.19.37)
       shadcn:
         specifier: ^3.8.5
         version: 3.8.5(@types/node@20.19.37)(typescript@5.9.3)
@@ -131,7 +131,7 @@ importers:
         version: 4.2.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.1.2(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@20.19.35))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.1.2(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@20.19.37))(typescript@5.9.3)
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -418,8 +418,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@dotenvx/dotenvx@1.54.1':
-    resolution: {integrity: sha512-41gU3q7v05GM92QPuPUf4CmUw+mmF8p4wLUh6MCRlxpCkJ9ByLcY9jUf6MwrMNmiKyG/rIckNxj9SCfmNCmCqw==}
+  '@dotenvx/dotenvx@1.52.0':
+    resolution: {integrity: sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w==}
     hasBin: true
 
   '@ecies/ciphers@0.2.5':
@@ -1963,6 +1963,12 @@ packages:
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
   '@typescript-eslint/eslint-plugin@8.57.0':
     resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3344,8 +3350,8 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.0.1:
+    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -5676,7 +5682,7 @@ snapshots:
     dependencies:
       commander: 11.1.0
       dotenv: 17.3.1
-      eciesjs: 0.4.18
+      eciesjs: 0.4.17
       execa: 5.1.1
       fdir: 6.5.0(picomatch@4.0.3)
       ignore: 5.3.2
@@ -5940,7 +5946,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -5949,7 +5955,7 @@ snapshots:
   '@jest/console@30.1.2':
     dependencies:
       '@jest/types': 30.0.5
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       chalk: 4.1.2
       jest-message-util: 30.1.0
       jest-util: 30.0.5
@@ -5962,14 +5968,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.35)
+      jest-config: 29.7.0(@types/node@20.19.37)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -5998,14 +6004,14 @@ snapshots:
       '@jest/test-result': 30.1.3
       '@jest/transform': 30.1.2
       '@jest/types': 30.0.5
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
-      jest-config: 30.1.3(@types/node@20.19.35)
+      jest-config: 30.1.3(@types/node@20.19.37)
       jest-haste-map: 30.1.0
       jest-message-util: 30.1.0
       jest-regex-util: 30.0.1
@@ -6034,21 +6040,21 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       jest-mock: 29.7.0
 
   '@jest/environment@30.1.2':
     dependencies:
       '@jest/fake-timers': 30.1.2
       '@jest/types': 30.0.5
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       jest-mock: 30.0.5
 
   '@jest/environment@30.3.0':
     dependencies:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       jest-mock: 30.3.0
 
   '@jest/expect-utils@29.7.0':
@@ -6088,7 +6094,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -6097,7 +6103,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.0.5
       '@sinonjs/fake-timers': 13.0.5
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       jest-message-util: 30.1.0
       jest-mock: 30.0.5
       jest-util: 30.0.5
@@ -6106,7 +6112,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
       '@sinonjs/fake-timers': 15.1.1
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
@@ -6142,7 +6148,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       jest-regex-util: 30.0.1
 
   '@jest/reporters@29.7.0':
@@ -6153,7 +6159,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -6182,7 +6188,7 @@ snapshots:
       '@jest/transform': 30.1.2
       '@jest/types': 30.0.5
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -6328,7 +6334,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -6338,7 +6344,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -6348,7 +6354,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -6382,7 +6388,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1
-      express-rate-limit: 8.3.1(express@5.2.1)
+      express-rate-limit: 8.2.1(express@5.2.1)
       hono: 4.12.7
       jose: 6.2.1
       json-schema-typed: 8.0.2
@@ -7397,7 +7403,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -7416,7 +7422,7 @@ snapshots:
 
   '@types/jsdom@20.0.1':
     dependencies:
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -7454,7 +7460,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
       '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -7932,9 +7938,9 @@ snapshots:
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001777
+      caniuse-lite: 1.0.30001776
       electron-to-chromium: 1.5.307
-      node-releases: 2.0.36
+      node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   bs-logger@0.2.6:
@@ -8067,13 +8073,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  create-jest@29.7.0(@types/node@20.19.35):
+  create-jest@29.7.0(@types/node@20.19.37):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.35)
+      jest-config: 29.7.0(@types/node@20.19.37)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -8350,7 +8356,6 @@ snapshots:
       has-symbols: 1.1.0
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
-      math-intrinsics: 1.1.0
       safe-array-concat: 1.1.3
 
   es-object-atoms@1.1.1:
@@ -8390,7 +8395,7 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-next@16.1.6(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.4(jiti@2.6.1)
@@ -8510,7 +8515,7 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
-      es-iterator-helpers: 1.3.0
+      es-iterator-helpers: 1.2.2
       eslint: 9.39.4(jiti@2.6.1)
       estraverse: 5.3.0
       hasown: 2.0.2
@@ -8665,7 +8670,7 @@ snapshots:
   express-rate-limit@8.2.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.0.1
 
   express@5.2.1:
     dependencies:
@@ -9056,7 +9061,7 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
-  ip-address@10.1.0: {}
+  ip-address@10.0.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -9305,7 +9310,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -9331,7 +9336,7 @@ snapshots:
       '@jest/expect': 30.1.2
       '@jest/test-result': 30.1.3
       '@jest/types': 30.0.5
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -9351,16 +9356,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.35):
+  jest-cli@29.7.0(@types/node@20.19.37):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.35)
+      create-jest: 29.7.0(@types/node@20.19.37)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.35)
+      jest-config: 29.7.0(@types/node@20.19.37)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -9370,7 +9375,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.1.3(@types/node@20.19.35):
+  jest-cli@30.1.3(@types/node@20.19.37):
     dependencies:
       '@jest/core': 30.1.3
       '@jest/test-result': 30.1.3
@@ -9378,7 +9383,7 @@ snapshots:
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.1.3(@types/node@20.19.35)
+      jest-config: 30.1.3(@types/node@20.19.37)
       jest-util: 30.0.5
       jest-validate: 30.1.0
       yargs: 17.7.2
@@ -9389,7 +9394,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.19.35):
+  jest-config@29.7.0(@types/node@20.19.37):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -9414,12 +9419,12 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.1.3(@types/node@20.19.35):
+  jest-config@30.1.3(@types/node@20.19.37):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -9446,7 +9451,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -9502,7 +9507,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -9516,7 +9521,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -9525,7 +9530,7 @@ snapshots:
       '@jest/environment': 30.1.2
       '@jest/fake-timers': 30.1.2
       '@jest/types': 30.0.5
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       jest-mock: 30.0.5
       jest-util: 30.0.5
       jest-validate: 30.1.0
@@ -9536,7 +9541,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -9551,7 +9556,7 @@ snapshots:
   jest-haste-map@30.1.0:
     dependencies:
       '@jest/types': 30.0.5
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -9566,7 +9571,7 @@ snapshots:
   jest-haste-map@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -9645,10 +9650,10 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
-  jest-mock-axios@4.9.0(@types/node@20.19.35):
+  jest-mock-axios@4.9.0(@types/node@20.19.37):
     dependencies:
       '@jest/globals': 30.3.0
-      jest: 30.1.3(@types/node@20.19.35)
+      jest: 30.1.3(@types/node@20.19.37)
       synchronous-promise: 2.0.17
     transitivePeerDependencies:
       - '@types/node'
@@ -9661,19 +9666,19 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       jest-util: 29.7.0
 
   jest-mock@30.0.5:
     dependencies:
       '@jest/types': 30.0.5
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       jest-util: 30.0.5
 
   jest-mock@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       jest-util: 30.3.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -9732,7 +9737,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -9758,7 +9763,7 @@ snapshots:
       '@jest/test-result': 30.1.3
       '@jest/transform': 30.1.2
       '@jest/types': 30.0.5
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -9787,7 +9792,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -9814,7 +9819,7 @@ snapshots:
       '@jest/test-result': 30.1.3
       '@jest/transform': 30.1.2
       '@jest/types': 30.0.5
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -9912,7 +9917,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -9921,7 +9926,7 @@ snapshots:
   jest-util@30.0.5:
     dependencies:
       '@jest/types': 30.0.5
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -9930,7 +9935,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -9958,7 +9963,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -9969,7 +9974,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.1.3
       '@jest/types': 30.0.5
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -9978,14 +9983,14 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@30.1.0:
     dependencies:
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.0.5
       merge-stream: 2.0.0
@@ -9993,30 +9998,30 @@ snapshots:
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 20.19.35
+      '@types/node': 20.19.37
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.3.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.35):
+  jest@29.7.0(@types/node@20.19.37):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.35)
+      jest-cli: 29.7.0(@types/node@20.19.37)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
       - ts-node
 
-  jest@30.1.3(@types/node@20.19.35):
+  jest@30.1.3(@types/node@20.19.37):
     dependencies:
       '@jest/core': 30.1.3
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.1.3(@types/node@20.19.35)
+      jest-cli: 30.1.3(@types/node@20.19.37)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -10322,7 +10327,7 @@ snapshots:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001777
+      caniuse-lite: 1.0.30001776
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -10951,7 +10956,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@dotenvx/dotenvx': 1.54.1
+      '@dotenvx/dotenvx': 1.52.0
       '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.1
@@ -11287,12 +11292,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.1.2(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@20.19.35))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.1.2(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@20.19.37))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@20.19.35)
+      jest: 29.7.0(@types/node@20.19.37)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6


### PR DESCRIPTION
- Updated `DictionaryPage` and `VocabularioPage` to utilize `useParlaUser` for fetching user-specific language IDs.
- Modified phrase population logic to include target language parameters.
- Improved state management for phrase deletion and added confirmation dialog in `VocabularioPage`.
- Adjusted `PhraseModal` to accept source and target language IDs as props.
- Refactored `DictionaryContext` to support dynamic target language during dictionary population.