### PR TITLE
feat(api-gateway): circuit breaker, graceful shutdown, tests, and docs    

### DIFF
--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -1,0 +1,88 @@
+# API Gateway
+
+Go reverse-proxy gateway that routes external traffic to four internal microservices: `auth`, `core`, `forum`, and `game`.
+
+## Architecture
+
+Every request passes through this middleware chain before reaching an upstream service:
+
+```
+Client → Security → RequestID → Logging → CORS → RateLimit → Auth → ReverseProxy → Microservice
+```
+
+| Middleware | What it does |
+|---|---|
+| Security | Sets `X-Content-Type-Options`, `X-Frame-Options`, and HSTS (production only) |
+| RequestID | Generates or propagates `X-Request-ID` across request and response |
+| Logging | Logs method, path, status code, and duration after the request completes |
+| CORS | Sets CORS headers; short-circuits OPTIONS preflight with 204 |
+| RateLimit | Token bucket per IP — 10 req/s, burst of 20 |
+| Auth | Validates Auth0 JWT; sets `X-User-Sub` from claims for upstream use |
+| ReverseProxy | Strips path prefix and forwards to the target service; includes circuit breaker |
+
+The circuit breaker per upstream opens after 5 consecutive 5xx responses and resets after 30 seconds.
+
+## Route table
+
+Defined in `config.json`. Path prefix is stripped before forwarding.
+
+| Path prefix | Service | Example |
+|---|---|---|
+| `/api/auth` | auth | `/api/auth/login` → `/login` |
+| `/api/core` | core | `/api/core/users` → `/users` |
+| `/api/forum` | forum | `/api/forum/posts` → `/posts` |
+| `/api/game` | game | `/api/game/scores` → `/scores` |
+| `/api/gamification` | game | `/api/gamification/points` → `/points` |
+
+### Adding a new service
+
+Add an entry to `config.json`:
+
+```json
+{
+  "path_prefix": "/api/myservice",
+  "service_name": "myservice"
+}
+```
+
+Then add the corresponding URL to `.env`:
+
+```
+SERVICE_MYSERVICE_URL=http://my-service:8080
+```
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `PORT` | Yes | Port the gateway listens on (e.g. `8080`) |
+| `ENVIRONMENT` | Yes | `production` enables HSTS; any other value disables it |
+| `AUTH0_DOMAIN` | Yes | Auth0 domain without `https://` (e.g. `foo.us.auth0.com`) |
+| `AUTH0_AUDIENCE` | Yes | Auth0 API audience (e.g. `https://my-api.com`) |
+| `SERVICE_AUTH_URL` | Yes | Base URL of the auth service |
+| `SERVICE_CORE_URL` | Yes | Base URL of the core service |
+| `SERVICE_FORUM_URL` | Yes | Base URL of the forum service |
+| `SERVICE_GAME_URL` | Yes | Base URL of the game/gamification service |
+
+## Running locally
+
+```bash
+cp .env.example .env   # fill in values
+go run ./cmd/main.go
+```
+
+The gateway logs a startup table with each registered service and its live health status.
+
+```
+GET /health   — probes each upstream's /health and returns aggregate status
+```
+
+## Running tests
+
+```bash
+go test ./...                        # all tests
+go test ./internal/middleware/...    # middleware unit tests
+go test ./internal/proxy/...         # proxy + circuit breaker tests
+go test ./config/...                 # config loading tests
+go test ./internal/router/... -v     # integration tests (starts real HTTP servers)
+```

--- a/api-gateway/cmd/main.go
+++ b/api-gateway/cmd/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"log"
 	"net/http"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"api-gateway/config"
 	"api-gateway/internal/router"
@@ -30,22 +34,37 @@ func main() {
 		log.Fatalf("failed to create router: %v", err)
 	}
 
+	// Set server with the mux provided by the router
 	server := &http.Server{
 		Addr:    ":" + cfg.Port,
 		Handler: mux,
 	}
 
-	//go func() {
-	//	log.Printf("API Gateway listening on %s", server.Addr)
-	//	if err = server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-	//		log.Fatalf("server failed: %v", err)
-	//	}
-	//}()
+	// Create a context that is canceled by Ctrl+C or SIGTERM
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
-	logInitialStatus(server, cfg)
-	if err = server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-		log.Fatalf("server failed: %v", err)
+	// Start the server in a goroutine
+	go func() {
+		logInitialStatus(server, cfg)
+		if err = server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("server failed: %v", err)
+		}
+	}()
+
+	// Wait until the stop signal
+	<-ctx.Done()
+	log.Println("shutting down gracefully...")
+
+	// 10 seconds left to complete pending requests
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		log.Fatalf("forced shutdown: %v", err)
 	}
+	log.Println("server stopped")
+
 }
 
 func logInitialStatus(server *http.Server, cfg *config.GeneralConfig) {

--- a/api-gateway/config.json
+++ b/api-gateway/config.json
@@ -15,6 +15,10 @@
     {
       "path_prefix": "/api/game",
       "service_name": "game"
+    },
+    {
+      "path_prefix": "/api/gamification",
+      "service_name": "game"
     }
   ]
 }

--- a/api-gateway/config/config_test.go
+++ b/api-gateway/config/config_test.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeConfigFile creates a temporary JSON config file in dir and returns its path.
+func writeConfigFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write temp config file: %v", err)
+	}
+	return path
+}
+
+// setRequiredEnvVars sets all env vars that Load() requires (except SERVICE_*_URL).
+func setRequiredEnvVars(t *testing.T) {
+	t.Helper()
+	t.Setenv("PORT", "8080")
+	t.Setenv("ENVIRONMENT", "staging")
+	t.Setenv("AUTH0_AUDIENCE", "test-audience")
+	t.Setenv("AUTH0_DOMAIN", "test.auth0.com")
+}
+
+// --- Load() ---
+
+func TestLoad_ValidConfig(t *testing.T) {
+	path := writeConfigFile(t, `{"routes":[{"path_prefix":"/api/auth","service_name":"auth"}]}`)
+
+	setRequiredEnvVars(t)
+	t.Setenv("SERVICE_AUTH_URL", "http://auth-service:8081")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() returned unexpected error: %v", err)
+	}
+
+	if cfg.Port != "8080" {
+		t.Errorf("Port: want %q, got %q", "8080", cfg.Port)
+	}
+	if cfg.Environment != "staging" {
+		t.Errorf("Environment: want %q, got %q", "staging", cfg.Environment)
+	}
+	if cfg.Auth.Audience != "test-audience" {
+		t.Errorf("Auth.Audience: want %q, got %q", "test-audience", cfg.Auth.Audience)
+	}
+	if cfg.Auth.Domain != "test.auth0.com" {
+		t.Errorf("Auth.Domain: want %q, got %q", "test.auth0.com", cfg.Auth.Domain)
+	}
+	if len(cfg.Routes) != 1 {
+		t.Fatalf("Routes: want 1 route, got %d", len(cfg.Routes))
+	}
+	if cfg.Routes[0].PathPrefix != "/api/auth" {
+		t.Errorf("Routes[0].PathPrefix: want %q, got %q", "/api/auth", cfg.Routes[0].PathPrefix)
+	}
+	if cfg.Routes[0].ServiceName != "auth" {
+		t.Errorf("Routes[0].ServiceName: want %q, got %q", "auth", cfg.Routes[0].ServiceName)
+	}
+	if cfg.Routes[0].TargetURL != "http://auth-service:8081" {
+		t.Errorf("Routes[0].TargetURL: want %q, got %q", "http://auth-service:8081", cfg.Routes[0].TargetURL)
+	}
+}
+
+func TestLoad_MissingJSONFile(t *testing.T) {
+	setRequiredEnvVars(t)
+
+	_, err := Load("/nonexistent/path/config.json")
+	if err == nil {
+		t.Error("Load() should return an error when the JSON file does not exist")
+	}
+}
+
+func TestLoad_MissingPORTEnvVar(t *testing.T) {
+	path := writeConfigFile(t, `{"routes":[{"path_prefix":"/api/auth","service_name":"auth"}]}`)
+
+	// Set everything except PORT
+	t.Setenv("ENVIRONMENT", "staging")
+	t.Setenv("AUTH0_AUDIENCE", "test-audience")
+	t.Setenv("AUTH0_DOMAIN", "test.auth0.com")
+	t.Setenv("SERVICE_AUTH_URL", "http://auth-service:8081")
+
+	_, err := Load(path)
+	if err == nil {
+		t.Error("Load() should return an error when PORT is not set")
+	}
+}
+
+func TestLoad_MissingServiceURL(t *testing.T) {
+	path := writeConfigFile(t, `{"routes":[{"path_prefix":"/api/auth","service_name":"auth"}]}`)
+
+	setRequiredEnvVars(t)
+	// SERVICE_AUTH_URL is intentionally not set
+
+	_, err := Load(path)
+	if err == nil {
+		t.Error("Load() should return an error when SERVICE_AUTH_URL is missing")
+	}
+}
+
+// --- InProduction() ---
+
+func TestInProduction_ReturnsTrueInProduction(t *testing.T) {
+	cfg := &GeneralConfig{Environment: "production"}
+	if !cfg.InProduction() {
+		t.Error("InProduction() should return true when Environment is \"production\"")
+	}
+}
+
+func TestInProduction_ReturnsFalseInStaging(t *testing.T) {
+	cfg := &GeneralConfig{Environment: "staging"}
+	if cfg.InProduction() {
+		t.Error("InProduction() should return false when Environment is \"staging\"")
+	}
+}

--- a/api-gateway/internal/middleware/cors_test.go
+++ b/api-gateway/internal/middleware/cors_test.go
@@ -1,0 +1,61 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCORS_SetsHeadersOnEveryRequest(t *testing.T) {
+	methods := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions}
+	for _, method := range methods {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(method, "/", nil)
+		CORS("https://example.com")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(w, r)
+
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+			t.Errorf("method=%s: Access-Control-Allow-Origin = %q, want %q", method, got, "https://example.com")
+		}
+		if got := w.Header().Get("Access-Control-Allow-Methods"); got == "" {
+			t.Errorf("method=%s: Access-Control-Allow-Methods should not be empty", method)
+		}
+		if got := w.Header().Get("Access-Control-Allow-Headers"); got == "" {
+			t.Errorf("method=%s: Access-Control-Allow-Headers should not be empty", method)
+		}
+		if got := w.Header().Get("Access-Control-Max-Age"); got == "" {
+			t.Errorf("method=%s: Access-Control-Max-Age should not be empty", method)
+		}
+	}
+}
+
+func TestCORS_OptionsReturns204AndDoesNotCallNext(t *testing.T) {
+	called := false
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodOptions, "/", nil)
+	CORS("*")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})).ServeHTTP(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("OPTIONS: status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+	if called {
+		t.Error("OPTIONS: next handler should not be called")
+	}
+}
+
+func TestCORS_NonOptionsCallsNext(t *testing.T) {
+	methods := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete}
+	for _, method := range methods {
+		called := false
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(method, "/", nil)
+		CORS("*")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		})).ServeHTTP(w, r)
+
+		if !called {
+			t.Errorf("method=%s: next handler was not called", method)
+		}
+	}
+}

--- a/api-gateway/internal/middleware/logging.go
+++ b/api-gateway/internal/middleware/logging.go
@@ -3,18 +3,37 @@ package middleware
 import (
 	"log/slog"
 	"net/http"
+	"time"
 )
+
+type responseRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rr *responseRecorder) WriteHeader(code int) {
+	rr.statusCode = code
+	rr.ResponseWriter.WriteHeader(code)
+}
 
 func Logging(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
 
-		next.ServeHTTP(w, r)
+		rr := &responseRecorder{
+			statusCode:     http.StatusOK,
+			ResponseWriter: w,
+		}
+
+		next.ServeHTTP(rr, r)
 
 		// Structure logging
 		slog.Info(
-			"request",
+			"REQUEST",
 			"method", r.Method,
 			"path", r.URL.Path,
+			"status", rr.statusCode,
+			"duration", time.Since(start).String(),
 			"request_id", r.Header.Get("X-Request-ID"),
 		)
 	})

--- a/api-gateway/internal/middleware/logging_test.go
+++ b/api-gateway/internal/middleware/logging_test.go
@@ -1,0 +1,73 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResponseRecorder_DefaultsTo200WhenWriteHeaderNeverCalled(t *testing.T) {
+	w := httptest.NewRecorder()
+	rr := &responseRecorder{
+		statusCode:     http.StatusOK,
+		ResponseWriter: w,
+	}
+
+	if rr.statusCode != http.StatusOK {
+		t.Errorf("default statusCode = %d, want %d", rr.statusCode, http.StatusOK)
+	}
+}
+
+func TestResponseRecorder_CapturesActualStatusWhenWriteHeaderCalled(t *testing.T) {
+	cases := []int{
+		http.StatusCreated,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusNotFound,
+		http.StatusInternalServerError,
+	}
+
+	for _, code := range cases {
+		w := httptest.NewRecorder()
+		rr := &responseRecorder{
+			statusCode:     http.StatusOK,
+			ResponseWriter: w,
+		}
+		rr.WriteHeader(code)
+
+		if rr.statusCode != code {
+			t.Errorf("WriteHeader(%d): statusCode = %d, want %d", code, rr.statusCode, code)
+		}
+	}
+}
+
+func TestLogging_AlwaysCallsNext(t *testing.T) {
+	called := false
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/some/path", nil)
+
+	Logging(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})).ServeHTTP(w, r)
+
+	if !called {
+		t.Error("next handler was not called")
+	}
+}
+
+func TestLogging_CallsNextWithDifferentMethods(t *testing.T) {
+	methods := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete}
+	for _, method := range methods {
+		called := false
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(method, "/", nil)
+
+		Logging(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		})).ServeHTTP(w, r)
+
+		if !called {
+			t.Errorf("method=%s: next handler was not called", method)
+		}
+	}
+}

--- a/api-gateway/internal/middleware/rate_limit.go
+++ b/api-gateway/internal/middleware/rate_limit.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"net"
 	"net/http"
 	"sync"
 
@@ -40,7 +41,7 @@ func RateLimit(rps float64, burst int) Middleware {
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ip := r.RemoteAddr
+			ip, _, _ := net.SplitHostPort(r.RemoteAddr)
 
 			if !limiter.getLimiter(ip).Allow() {
 				http.Error(w, "too many requests", http.StatusTooManyRequests)

--- a/api-gateway/internal/middleware/rate_limit_test.go
+++ b/api-gateway/internal/middleware/rate_limit_test.go
@@ -1,0 +1,95 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRateLimit_RequestsWithinLimitPassThrough(t *testing.T) {
+	handler := RateLimit(10, 5)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 5; i++ {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.RemoteAddr = "1.2.3.4:1234"
+		handler.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("request %d: status = %d, want %d", i+1, w.Code, http.StatusOK)
+		}
+	}
+}
+
+func TestRateLimit_RequestsExceedingLimitGet429(t *testing.T) {
+	handler := RateLimit(1, 1)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	var got429 bool
+	for i := 0; i < 20; i++ {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.RemoteAddr = "5.6.7.8:9999"
+		handler.ServeHTTP(w, r)
+		if w.Code == http.StatusTooManyRequests {
+			got429 = true
+			break
+		}
+	}
+
+	if !got429 {
+		t.Error("expected at least one 429 response after exhausting the burst, got none")
+	}
+}
+
+func TestRateLimit_DifferentIPsHaveIndependentLimiters(t *testing.T) {
+	handler := RateLimit(1, 1)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 10; i++ {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.RemoteAddr = "10.0.0.1:1111"
+		handler.ServeHTTP(w, r)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.2:1111"
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("fresh IP got status %d, want %d — limiters are not independent", w.Code, http.StatusOK)
+	}
+}
+
+func TestRateLimit_IPExtractedCorrectlyFromRemoteAddrWithPort(t *testing.T) {
+	cases := []struct {
+		remoteAddr string
+		wantIP     string
+	}{
+		{"1.2.3.4:5678", "1.2.3.4"},
+		{"192.168.1.100:80", "192.168.1.100"},
+	}
+
+	for _, tc := range cases {
+		ip, _, err := net.SplitHostPort(tc.remoteAddr)
+		if err != nil {
+			t.Fatalf("remoteAddr=%s: SplitHostPort error: %v", tc.remoteAddr, err)
+		}
+		if ip != tc.wantIP {
+			t.Errorf("remoteAddr=%s: got IP %q, want %q", tc.remoteAddr, ip, tc.wantIP)
+		}
+
+		limiter := newIPLimiter(100, 10)
+		l1 := limiter.getLimiter(ip)
+		l2 := limiter.getLimiter(tc.wantIP)
+		if l1 != l2 {
+			t.Errorf("remoteAddr=%s: different limiter for extracted IP %q vs wantIP %q", tc.remoteAddr, ip, tc.wantIP)
+		}
+	}
+}

--- a/api-gateway/internal/middleware/request_id_test.go
+++ b/api-gateway/internal/middleware/request_id_test.go
@@ -1,0 +1,69 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequestID_ReusesExistingID(t *testing.T) {
+	existing := "my-existing-id"
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Request-ID", existing)
+
+	RequestID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(w, r)
+
+	if got := w.Header().Get("X-Request-ID"); got != existing {
+		t.Errorf("response X-Request-ID = %q, want %q", got, existing)
+	}
+}
+
+func TestRequestID_ReusesExistingIDOnRequest(t *testing.T) {
+	existing := "my-existing-id"
+	var captured string
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Request-ID", existing)
+
+	RequestID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Get("X-Request-ID")
+	})).ServeHTTP(w, r)
+
+	if captured != existing {
+		t.Errorf("request X-Request-ID = %q, want %q", captured, existing)
+	}
+}
+
+func TestRequestID_GeneratesNewIDWhenMissing(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	RequestID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(w, r)
+
+	if got := w.Header().Get("X-Request-ID"); got == "" {
+		t.Error("X-Request-ID should be generated when not provided, got empty string")
+	}
+}
+
+func TestRequestID_GeneratedIDSetOnBothRequestAndResponse(t *testing.T) {
+	var requestID string
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	RequestID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestID = r.Header.Get("X-Request-ID")
+	})).ServeHTTP(w, r)
+
+	responseID := w.Header().Get("X-Request-ID")
+
+	if requestID == "" {
+		t.Error("X-Request-ID not set on request")
+	}
+	if responseID == "" {
+		t.Error("X-Request-ID not set on response")
+	}
+	if requestID != responseID {
+		t.Errorf("request ID %q != response ID %q", requestID, responseID)
+	}
+}

--- a/api-gateway/internal/middleware/security_test.go
+++ b/api-gateway/internal/middleware/security_test.go
@@ -1,0 +1,61 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSecurity_AlwaysSetsXContentTypeOptions(t *testing.T) {
+	for _, inProduction := range []bool{true, false} {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		Security(inProduction)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(w, r)
+		if got := w.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+			t.Errorf("inProduction=%v: X-Content-Type-Options = %q, want %q", inProduction, got, "nosniff")
+		}
+	}
+}
+
+func TestSecurity_AlwaysSetsXFrameOptions(t *testing.T) {
+	for _, inProduction := range []bool{true, false} {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		Security(inProduction)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(w, r)
+		if got := w.Header().Get("X-Frame-Options"); got != "DENY" {
+			t.Errorf("inProduction=%v: X-Frame-Options = %q, want %q", inProduction, got, "DENY")
+		}
+	}
+}
+
+func TestSecurity_SetsSTSWhenInProduction(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	Security(true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(w, r)
+	if got := w.Header().Get("Strict-Transport-Security"); got == "" {
+		t.Error("Strict-Transport-Security should be set in production, got empty string")
+	}
+}
+
+func TestSecurity_DoesNotSetSTSWhenNotInProduction(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	Security(false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(w, r)
+	if got := w.Header().Get("Strict-Transport-Security"); got != "" {
+		t.Errorf("Strict-Transport-Security should not be set outside production, got %q", got)
+	}
+}
+
+func TestSecurity_AlwaysCallsNext(t *testing.T) {
+	for _, inProduction := range []bool{true, false} {
+		called := false
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		Security(inProduction)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		})).ServeHTTP(w, r)
+		if !called {
+			t.Errorf("inProduction=%v: next handler was not called", inProduction)
+		}
+	}
+}

--- a/api-gateway/internal/proxy/circuit_breaker.go
+++ b/api-gateway/internal/proxy/circuit_breaker.go
@@ -1,0 +1,68 @@
+package proxy
+
+import (
+	"sync"
+	"time"
+)
+
+type state int
+
+const (
+	closed   state = iota // normal, requests pass
+	halfOpen              // testing if the microservice recovered
+	open                  // cut, request are not forwarded
+)
+
+type CircuitBreaker struct {
+	mu           sync.Mutex
+	state        state
+	failures     int
+	maxFailures  int
+	resetTimeout time.Duration
+	lastFailure  time.Time
+}
+
+func NewCircuitBreaker(maxFailures int, resetTimeout time.Duration) *CircuitBreaker {
+	return &CircuitBreaker{
+		state:        closed,
+		maxFailures:  maxFailures,
+		resetTimeout: resetTimeout,
+	}
+}
+
+func (cb *CircuitBreaker) allow() bool {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	switch cb.state {
+	case closed:
+		return true
+	case open:
+		if time.Since(cb.lastFailure) >= cb.resetTimeout {
+			cb.state = halfOpen
+			return true
+		}
+	case halfOpen:
+		return false // another request is testing
+	}
+	return false
+}
+
+func (cb *CircuitBreaker) recordSuccess() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	cb.failures = 0
+	cb.state = closed
+}
+
+func (cb *CircuitBreaker) recordFailure() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	cb.failures++
+	cb.lastFailure = time.Now()
+	if cb.failures >= cb.maxFailures || cb.state == halfOpen {
+		cb.state = open
+	}
+}

--- a/api-gateway/internal/proxy/circuit_breaker_test.go
+++ b/api-gateway/internal/proxy/circuit_breaker_test.go
@@ -1,0 +1,97 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCircuitBreaker_StartsClosedAndAllowsRequests(t *testing.T) {
+	cb := NewCircuitBreaker(3, time.Second)
+	if !cb.allow() {
+		t.Error("new circuit breaker should be closed and allow requests")
+	}
+}
+
+func TestCircuitBreaker_OpensAfterMaxFailures(t *testing.T) {
+	cb := NewCircuitBreaker(3, time.Second)
+	for i := 0; i < 3; i++ {
+		cb.recordFailure()
+	}
+	if cb.allow() {
+		t.Error("circuit breaker should be open after maxFailures failures")
+	}
+}
+
+func TestCircuitBreaker_HalfOpenAfterResetTimeout(t *testing.T) {
+	cb := NewCircuitBreaker(1, 50*time.Millisecond)
+	cb.recordFailure()
+
+	if cb.allow() {
+		t.Error("should be open immediately after maxFailures")
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	if !cb.allow() {
+		t.Error("should transition to half-open (allow one request) after resetTimeout")
+	}
+}
+
+func TestCircuitBreaker_SuccessInHalfOpenResetsToClose(t *testing.T) {
+	cb := NewCircuitBreaker(1, 50*time.Millisecond)
+	cb.recordFailure()
+	time.Sleep(60 * time.Millisecond)
+	cb.allow()
+
+	cb.recordSuccess()
+
+	if !cb.allow() {
+		t.Error("circuit breaker should be closed after success in half-open state")
+	}
+}
+
+func TestCircuitBreaker_FailureInHalfOpenGoesBackToOpen(t *testing.T) {
+	cb := NewCircuitBreaker(1, 50*time.Millisecond)
+	cb.recordFailure()
+	time.Sleep(60 * time.Millisecond)
+	cb.allow()
+
+	cb.recordFailure()
+
+	if cb.allow() {
+		t.Error("circuit breaker should go back to open immediately after failure in half-open state")
+	}
+}
+
+func TestCircuitBreaker_RecordSuccessResetFailureCount(t *testing.T) {
+	cb := NewCircuitBreaker(3, time.Second)
+	cb.recordFailure()
+	cb.recordFailure()
+	cb.recordSuccess()
+
+	if cb.failures != 0 {
+		t.Errorf("recordSuccess should reset failure count to 0, got %d", cb.failures)
+	}
+}
+
+func TestCircuitBreaker_DoesNotOpenBeforeMaxFailures(t *testing.T) {
+	cb := NewCircuitBreaker(3, time.Second)
+	cb.recordFailure()
+	cb.recordFailure()
+
+	if !cb.allow() {
+		t.Error("circuit breaker should still be closed after fewer failures than maxFailures")
+	}
+}
+
+func TestCircuitBreaker_HalfOpenBlocksSecondConcurrentRequest(t *testing.T) {
+	cb := NewCircuitBreaker(1, 50*time.Millisecond)
+	cb.recordFailure()
+	time.Sleep(60 * time.Millisecond)
+
+	cb.allow()
+
+	if cb.allow() {
+		t.Error("half-open should block a second request while one is already testing")
+	}
+}

--- a/api-gateway/internal/proxy/proxy.go
+++ b/api-gateway/internal/proxy/proxy.go
@@ -1,12 +1,24 @@
 package proxy
 
 import (
-	"log"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"time"
 )
+
+type responseRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rr *responseRecorder) WriteHeader(code int) {
+	rr.statusCode = code
+	rr.ResponseWriter.WriteHeader(code)
+}
 
 func New(targetURL string, pathPrefix string) (http.Handler, error) {
 	target, err := url.Parse(targetURL)
@@ -14,9 +26,21 @@ func New(targetURL string, pathPrefix string) (http.Handler, error) {
 		return nil, err
 	}
 
+	transport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: 5 * time.Second, // Timeout for establishing the TCP connection
+		}).DialContext,
+		ResponseHeaderTimeout: 10 * time.Second, // Timeout waiting for the first response
+		MaxIdleConns:          10,               // Maximum of IDLE connections
+		MaxIdleConnsPerHost:   5,
+		IdleConnTimeout:       90 * time.Second, // Close IDLE connections after 90 seconds
+	}
+
 	proxy := &httputil.ReverseProxy{
+		Transport: transport,
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			pr.SetURL(target)
+			pr.SetXForwarded()
 
 			// Remove original prefix
 			originalPath := pr.In.URL.Path
@@ -30,8 +54,25 @@ func New(targetURL string, pathPrefix string) (http.Handler, error) {
 		},
 	}
 
+	cb := NewCircuitBreaker(5, 30*time.Second)
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("Perrito, que quiere? %s", r.URL)
-		proxy.ServeHTTP(w, r)
+		if !cb.allow() {
+			http.Error(w, fmt.Sprintf("service %s is unavailable", target.Host), http.StatusServiceUnavailable)
+			return
+		}
+
+		rr := &responseRecorder{
+			ResponseWriter: w,
+			statusCode:     http.StatusOK,
+		}
+		proxy.ServeHTTP(rr, r)
+
+		if rr.statusCode >= 500 {
+			cb.recordFailure()
+		} else {
+			cb.recordSuccess()
+		}
+
 	}), nil
 }

--- a/api-gateway/internal/proxy/proxy_test.go
+++ b/api-gateway/internal/proxy/proxy_test.go
@@ -1,0 +1,167 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// startUpstream creates a test HTTP server with the given handler and returns it.
+// The server is closed automatically when the test finishes.
+func startUpstream(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// makeRequest sends a GET request through handler and returns the recorded response.
+func makeRequest(t *testing.T, handler http.Handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+	return rw
+}
+
+// tripBreaker sends n requests that will all receive 500 from the upstream, driving
+// the circuit breaker to the open state. It calls t.Fatal if New() fails.
+func tripBreaker(t *testing.T, handler http.Handler, n int, requestPath string) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		makeRequest(t, handler, requestPath)
+	}
+}
+
+// --- Path prefix stripping ---
+
+func TestNew_PathPrefixIsStripped(t *testing.T) {
+	var receivedPath string
+	upstream := startUpstream(t, func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler, err := New(upstream.URL, "/api/auth")
+	if err != nil {
+		t.Fatalf("New() returned unexpected error: %v", err)
+	}
+
+	makeRequest(t, handler, "/api/auth/login")
+
+	if receivedPath != "/login" {
+		t.Errorf("upstream received path %q, want %q", receivedPath, "/login")
+	}
+}
+
+func TestNew_PathPrefixStrippedToRoot(t *testing.T) {
+	var receivedPath string
+	upstream := startUpstream(t, func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler, err := New(upstream.URL, "/api/auth")
+	if err != nil {
+		t.Fatalf("New() returned unexpected error: %v", err)
+	}
+
+	makeRequest(t, handler, "/api/auth")
+
+	// TrimPrefix("/api/auth", "/api/auth") == "" which the proxy sends as empty;
+	// httputil normalises that to "/" on the upstream side.
+	if receivedPath != "" && receivedPath != "/" {
+		t.Errorf("upstream received path %q, want %q or %q", receivedPath, "", "/")
+	}
+}
+
+// --- CORS header removal ---
+
+func TestNew_UpstreamCORSHeadersAreDeleted(t *testing.T) {
+	upstream := startUpstream(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler, err := New(upstream.URL, "/api/auth")
+	if err != nil {
+		t.Fatalf("New() returned unexpected error: %v", err)
+	}
+
+	rw := makeRequest(t, handler, "/api/auth/resource")
+
+	corsHeaders := []string{
+		"Access-Control-Allow-Origin",
+		"Access-Control-Allow-Methods",
+		"Access-Control-Allow-Headers",
+	}
+	for _, h := range corsHeaders {
+		if got := rw.Header().Get(h); got != "" {
+			t.Errorf("response header %q should be deleted, but got %q", h, got)
+		}
+	}
+}
+
+// --- Circuit breaker integration ---
+
+// alwaysError is a handler that always returns 500.
+func alwaysError(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusInternalServerError)
+}
+
+// alwaysOK is a handler that always returns 200.
+func alwaysOK(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func TestNew_CircuitBreakerOpensAfter5Failures(t *testing.T) {
+	upstream := startUpstream(t, alwaysError)
+
+	handler, err := New(upstream.URL, "/api/svc")
+	if err != nil {
+		t.Fatalf("New() returned unexpected error: %v", err)
+	}
+
+	// Send exactly maxFailures (5) requests to trip the breaker.
+	tripBreaker(t, handler, 5, "/api/svc/endpoint")
+
+	// The 6th request should be rejected by the open circuit breaker, not forwarded.
+	rw := makeRequest(t, handler, "/api/svc/endpoint")
+	if rw.Code != http.StatusServiceUnavailable {
+		t.Errorf("6th request: want status %d (circuit open), got %d", http.StatusServiceUnavailable, rw.Code)
+	}
+}
+
+func TestNew_CircuitBreakerResetAfterTimeout(t *testing.T) {
+	// Build a circuit breaker directly with a short resetTimeout so the test
+	// doesn't need to wait 30 s (the hardcoded value inside New()).
+	// Because we are in the same package (package proxy) we can instantiate
+	// CircuitBreaker directly and verify its state machine independently of
+	// the HTTP layer.
+	cb := NewCircuitBreaker(5, 50*time.Millisecond)
+
+	// Trip the breaker.
+	for i := 0; i < 5; i++ {
+		cb.recordFailure()
+	}
+	if cb.allow() {
+		t.Fatal("circuit breaker should be open immediately after maxFailures")
+	}
+
+	// Wait for the reset timeout to expire.
+	time.Sleep(60 * time.Millisecond)
+
+	// Now allow() should transition to halfOpen and return true.
+	if !cb.allow() {
+		t.Fatal("circuit breaker should allow a probe request after resetTimeout")
+	}
+
+	// A successful probe should close the breaker.
+	cb.recordSuccess()
+	if !cb.allow() {
+		t.Error("circuit breaker should be closed (allow requests) after a successful probe")
+	}
+}

--- a/api-gateway/internal/router/router.go
+++ b/api-gateway/internal/router/router.go
@@ -4,8 +4,8 @@ import (
 	"api-gateway/config"
 	"api-gateway/internal/middleware"
 	"api-gateway/internal/proxy"
+	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"time"
 )
@@ -15,9 +15,23 @@ func New(cfg *config.GeneralConfig) (*http.ServeMux, error) {
 
 	// General health check: includes this api gateway and the microservices
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
-		log.Print("Preguntaste por mi salud?")
+		status := map[string]string{}
+		allHealthy := true
+
+		for _, route := range cfg.Routes {
+			if CheckService(route.TargetURL + "/health") {
+				status[route.ServiceName] = "OK"
+			} else {
+				status[route.ServiceName] = "NOT OK"
+				allHealthy = false
+			}
+		}
+
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte("listo perrito todo saludable\n"))
+		if !allHealthy {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+		json.NewEncoder(w).Encode(status)
 	})
 
 	// Create auth middleware

--- a/api-gateway/internal/router/router_integration_test.go
+++ b/api-gateway/internal/router/router_integration_test.go
@@ -1,0 +1,566 @@
+package router
+
+import (
+	"api-gateway/config"
+	"api-gateway/internal/middleware"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/auth0/go-jwt-middleware/v3/jwks"
+	"github.com/auth0/go-jwt-middleware/v3/validator"
+	jwtmiddleware "github.com/auth0/go-jwt-middleware/v3"
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/lestrrat-go/jwx/v3/jwt"
+)
+
+// testConfig builds a GeneralConfig with the given routes, pointed at the
+// local JWKS server whose host:port is in authDomain.
+func testConfig(routes []config.ServiceRoute, authDomain string) *config.GeneralConfig {
+	return &config.GeneralConfig{
+		Port:        "8080",
+		Environment: "test",
+		Auth: config.AuthConfig{
+			Domain:   authDomain,
+			Audience: "test-audience",
+		},
+		Routes: routes,
+	}
+}
+
+// newHealthOnlyMux builds a mux that only registers GET /health (no proxy
+// routes, so no auth middleware is ever created). Useful for health tests.
+func newHealthOnlyMux(t *testing.T, routes []config.ServiceRoute) http.Handler {
+	t.Helper()
+	// Use a deliberately broken domain — auth middleware is created but never
+	// called for the /health endpoint, so JWKS discovery never fires.
+	cfg := testConfig(routes, "invalid.domain.test")
+	mux, err := New(cfg)
+	if err != nil {
+		t.Fatalf("router.New: %v", err)
+	}
+	return mux
+}
+
+// newFullMux creates a complete router including middleware-wrapped proxy
+// routes. The auth domain is deliberately invalid; tests that never hit the
+// auth layer (OPTIONS, rate-limit exhaustion, security headers returning 401)
+// still work correctly because the middleware chain short-circuits early.
+func newFullMux(t *testing.T, routes []config.ServiceRoute) http.Handler {
+	t.Helper()
+	cfg := testConfig(routes, "invalid.domain.test")
+	mux, err := New(cfg)
+	if err != nil {
+		t.Fatalf("router.New: %v", err)
+	}
+	return mux
+}
+
+// fakeUpstream returns a test server that always responds with the given
+// status code and records the request path it received.
+func fakeUpstream(t *testing.T, statusCode int, receivedPath *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if receivedPath != nil {
+			*receivedPath = r.URL.Path
+		}
+		w.WriteHeader(statusCode)
+	}))
+}
+
+// ── Test 1: Health endpoint – all upstreams healthy ───────────────────────────
+
+func TestHealthAllHealthy(t *testing.T) {
+	svcA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svcA.Close()
+
+	svcB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svcB.Close()
+
+	routes := []config.ServiceRoute{
+		{PathPrefix: "/api/alpha", ServiceName: "alpha", TargetURL: svcA.URL},
+		{PathPrefix: "/api/beta", ServiceName: "beta", TargetURL: svcB.URL},
+	}
+	mux := newHealthOnlyMux(t, routes)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/health", nil)
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	for _, svc := range []string{"alpha", "beta"} {
+		if got := body[svc]; got != "OK" {
+			t.Errorf("service %q: got %q, want %q", svc, got, "OK")
+		}
+	}
+}
+
+// ── Test 2: Health endpoint – one upstream unhealthy ──────────────────────────
+
+func TestHealthOneUnhealthy(t *testing.T) {
+	svcOK := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svcOK.Close()
+
+	svcBad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer svcBad.Close()
+
+	routes := []config.ServiceRoute{
+		{PathPrefix: "/api/good", ServiceName: "good", TargetURL: svcOK.URL},
+		{PathPrefix: "/api/bad", ServiceName: "bad", TargetURL: svcBad.URL},
+	}
+	mux := newHealthOnlyMux(t, routes)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/health", nil)
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if got := body["good"]; got != "OK" {
+		t.Errorf("service good: got %q, want %q", got, "OK")
+	}
+	if got := body["bad"]; got != "NOT OK" {
+		t.Errorf("service bad: got %q, want %q", got, "NOT OK")
+	}
+}
+
+// ── Test 3: CORS preflight short-circuits before auth ─────────────────────────
+
+func TestCORSPreflightShortCircuitsBeforeAuth(t *testing.T) {
+	upstreamReached := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamReached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	routes := []config.ServiceRoute{
+		{PathPrefix: "/api/auth", ServiceName: "auth", TargetURL: upstream.URL},
+	}
+	mux := newFullMux(t, routes)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodOptions, "/api/auth/login", nil)
+	r.Header.Set("Origin", "http://localhost:3000")
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204 from preflight, got %d", w.Code)
+	}
+	if upstreamReached {
+		t.Error("upstream should not have been reached during OPTIONS preflight")
+	}
+}
+
+// ── Test 4: Security headers always present ───────────────────────────────────
+
+func TestSecurityHeadersAlwaysPresent(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	routes := []config.ServiceRoute{
+		{PathPrefix: "/api/auth", ServiceName: "auth", TargetURL: upstream.URL},
+	}
+	mux := newFullMux(t, routes)
+
+	// Send a GET without a token – auth middleware will reject with 401.
+	// Security headers are set by Security middleware, which runs first.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/auth/profile", nil)
+	mux.ServeHTTP(w, r)
+
+	// The request should fail (401 or 500 from JWKS unreachable), but
+	// security headers must be present regardless.
+	if got := w.Header().Get("X-Content-Type-Options"); got == "" {
+		t.Error("X-Content-Type-Options header missing")
+	}
+	if got := w.Header().Get("X-Frame-Options"); got == "" {
+		t.Error("X-Frame-Options header missing")
+	}
+}
+
+// ── Test 5: Request-ID generated when absent ──────────────────────────────────
+
+func TestRequestIDGeneratedWhenAbsent(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	routes := []config.ServiceRoute{
+		{PathPrefix: "/api/auth", ServiceName: "auth", TargetURL: upstream.URL},
+	}
+	mux := newFullMux(t, routes)
+
+	// OPTIONS bypasses auth, so the full middleware chain (Security →
+	// RequestID → … → CORS) runs and we get a clean 204 response.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodOptions, "/api/auth/ping", nil)
+	mux.ServeHTTP(w, r)
+
+	id := w.Header().Get("X-Request-ID")
+	if id == "" {
+		t.Error("expected a non-empty X-Request-ID header when none was provided")
+	}
+}
+
+// ── Test 6: Request-ID propagated when present ────────────────────────────────
+
+func TestRequestIDPropagatedWhenPresent(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	routes := []config.ServiceRoute{
+		{PathPrefix: "/api/auth", ServiceName: "auth", TargetURL: upstream.URL},
+	}
+	mux := newFullMux(t, routes)
+
+	const wantID = "test-123"
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodOptions, "/api/auth/ping", nil)
+	r.Header.Set("X-Request-ID", wantID)
+	mux.ServeHTTP(w, r)
+
+	if got := w.Header().Get("X-Request-ID"); got != wantID {
+		t.Errorf("X-Request-ID = %q, want %q", got, wantID)
+	}
+}
+
+// ── Test 7: Rate limiting returns 429 after burst ─────────────────────────────
+
+func TestRateLimitReturns429AfterBurst(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	routes := []config.ServiceRoute{
+		{PathPrefix: "/api/auth", ServiceName: "auth", TargetURL: upstream.URL},
+	}
+	mux := newFullMux(t, routes)
+
+	// router.New configures RateLimit(10, 20): burst=20, so the 21st
+	// synchronous request from the same IP must be rejected.
+	//
+	// We use GET (not OPTIONS) because OPTIONS short-circuits at the CORS
+	// middleware, which runs before RateLimit. A GET request passes through
+	// CORS and reaches the RateLimit middleware, which will fire 429 once the
+	// bucket is exhausted — before the Auth middleware even has a chance to run.
+	var got429 bool
+	for i := 0; i < 25; i++ {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/api/auth/ping", nil)
+		r.RemoteAddr = "192.0.2.1:9999" // fixed IP so all share one bucket
+		mux.ServeHTTP(w, r)
+		if w.Code == http.StatusTooManyRequests {
+			got429 = true
+			break
+		}
+	}
+
+	if !got429 {
+		t.Error("expected at least one 429 after exhausting the rate-limit burst, got none")
+	}
+}
+
+// ── JWT test helpers ───────────────────────────────────────────────────────────
+
+// generateRSAKeyPair creates a 2048-bit RSA key pair for use in tests.
+func generateRSAKeyPair(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	return key
+}
+
+// jwksServer spins up an httptest.Server that serves the JWKS derived from
+// the given RSA private key at /.well-known/jwks.json.
+// It returns the server and the raw URL of the JWKS endpoint.
+func jwksServer(t *testing.T, privKey *rsa.PrivateKey) (*httptest.Server, string) {
+	t.Helper()
+
+	pubJWK, err := jwk.PublicKeyOf(privKey)
+	if err != nil {
+		t.Fatalf("jwk.PublicKeyOf: %v", err)
+	}
+	// Give the key an ID so the JWT header can reference it.
+	if err := pubJWK.Set(jwk.KeyIDKey, "test-key-1"); err != nil {
+		t.Fatalf("set kid: %v", err)
+	}
+	// Mark algorithm for interoperability.
+	if err := pubJWK.Set(jwk.AlgorithmKey, jwa.RS256()); err != nil {
+		t.Fatalf("set alg: %v", err)
+	}
+
+	keySet := jwk.NewSet()
+	if err := keySet.AddKey(pubJWK); err != nil {
+		t.Fatalf("add key to set: %v", err)
+	}
+
+	keySetJSON, err := json.Marshal(keySet)
+	if err != nil {
+		t.Fatalf("marshal JWKS: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(keySetJSON)
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, srv.URL + "/.well-known/jwks.json"
+}
+
+// signToken mints a signed JWT using the given private key.
+// issuer must be "https://{domain}/" to match what middleware.Auth expects.
+func signToken(t *testing.T, privKey *rsa.PrivateKey, issuer, audience, subject string) string {
+	t.Helper()
+
+	tok := jwt.New()
+	if err := tok.Set(jwt.IssuerKey, issuer); err != nil {
+		t.Fatalf("set iss: %v", err)
+	}
+	if err := tok.Set(jwt.AudienceKey, audience); err != nil {
+		t.Fatalf("set aud: %v", err)
+	}
+	if err := tok.Set(jwt.SubjectKey, subject); err != nil {
+		t.Fatalf("set sub: %v", err)
+	}
+	if err := tok.Set(jwt.IssuedAtKey, time.Now()); err != nil {
+		t.Fatalf("set iat: %v", err)
+	}
+	if err := tok.Set(jwt.ExpirationKey, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("set exp: %v", err)
+	}
+
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256(), privKey))
+	if err != nil {
+		t.Fatalf("jwt.Sign: %v", err)
+	}
+	return string(signed)
+}
+
+// buildAuthMiddlewareWithLocalJWKS constructs an Auth middleware that fetches
+// JWKS directly from a local HTTP URL (bypassing OIDC discovery and the HTTPS
+// enforcement that would block a plain httptest.Server). This is the only way
+// to test JWT validation without a real Auth0 tenant.
+//
+// Background: middleware.Auth hard-codes an "https://" prefix for the issuer
+// URL, which causes the Auth0 OIDC library to reject any jwks_uri that isn't
+// also HTTPS. WithCustomJWKSURI skips discovery entirely, so the HTTP JWKS
+// server is accepted.
+func buildAuthMiddlewareWithLocalJWKS(
+	t *testing.T,
+	issuer string,
+	audience string,
+	jwksURL string,
+) middleware.Middleware {
+	t.Helper()
+
+	issuerURL, err := url.Parse(issuer)
+	if err != nil {
+		t.Fatalf("parse issuer URL: %v", err)
+	}
+	customJWKSURI, err := url.Parse(jwksURL)
+	if err != nil {
+		t.Fatalf("parse JWKS URL: %v", err)
+	}
+
+	provider, err := jwks.NewCachingProvider(
+		jwks.WithIssuerURL(issuerURL),
+		jwks.WithCustomJWKSURI(customJWKSURI),
+	)
+	if err != nil {
+		t.Fatalf("NewCachingProvider: %v", err)
+	}
+
+	jwtValidator, err := validator.New(
+		validator.WithKeyFunc(provider.KeyFunc),
+		validator.WithAlgorithm(validator.RS256),
+		validator.WithIssuer(issuer),
+		validator.WithAudience(audience),
+	)
+	if err != nil {
+		t.Fatalf("validator.New: %v", err)
+	}
+
+	jwtMiddleware, err := jwtmiddleware.New(
+		jwtmiddleware.WithValidator(jwtValidator),
+	)
+	if err != nil {
+		t.Fatalf("jwtmiddleware.New: %v", err)
+	}
+
+	return func(next http.Handler) http.Handler {
+		return jwtMiddleware.CheckJWT(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		}))
+	}
+}
+
+// buildJWTTestMux builds a minimal http.ServeMux with a single proxy route
+// protected by a locally-pointed JWT middleware. This avoids the HTTPS
+// restriction imposed by router.New → middleware.Auth.
+func buildJWTTestMux(
+	t *testing.T,
+	upstream *httptest.Server,
+	pathPrefix string,
+	authMw middleware.Middleware,
+) http.Handler {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	middlewares := []middleware.Middleware{
+		middleware.Security(false),
+		middleware.RequestID,
+		middleware.Logging,
+		middleware.CORS("http://localhost:3000"),
+		middleware.RateLimit(1000, 1000), // effectively unlimited for JWT tests
+		authMw,
+	}
+
+	// Strip pathPrefix when forwarding – mirrors what proxy.New does.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		stripped := strings.TrimPrefix(r.URL.Path, pathPrefix)
+		proxyReq, err := http.NewRequest(r.Method, upstream.URL+stripped, r.Body)
+		if err != nil {
+			http.Error(w, "proxy error", http.StatusInternalServerError)
+			return
+		}
+		proxyReq.Header = r.Header.Clone()
+
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Do(proxyReq)
+		if err != nil {
+			http.Error(w, "upstream error", http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+
+		for k, vv := range resp.Header {
+			for _, v := range vv {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+	})
+
+	mux.Handle(pathPrefix+"/", middleware.Chain(handler, middlewares...))
+	return mux
+}
+
+// ── Test 8: Valid JWT routes request to upstream with prefix stripped ──────────
+
+func TestValidJWTRoutesToUpstreamWithPrefixStripped(t *testing.T) {
+	var receivedPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	privKey := generateRSAKeyPair(t)
+	_, jwksURL := jwksServer(t, privKey)
+
+	const (
+		domain   = "auth.example.test"
+		issuer   = "https://" + domain + "/"
+		audience = "test-audience"
+		subject  = "user|abc123"
+		prefix   = "/api/auth"
+	)
+
+	authMw := buildAuthMiddlewareWithLocalJWKS(t, issuer, audience, jwksURL)
+	mux := buildJWTTestMux(t, upstream, prefix, authMw)
+
+	token := signToken(t, privKey, issuer, audience, subject)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, prefix+"/login", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		body, _ := io.ReadAll(w.Body)
+		t.Fatalf("expected 200, got %d — body: %s", w.Code, body)
+	}
+	// The upstream must receive "/login", not "/api/auth/login".
+	if receivedPath != "/login" {
+		t.Errorf("upstream received path %q, want %q", receivedPath, "/login")
+	}
+}
+
+// ── Test 9: Invalid JWT returns 401 ───────────────────────────────────────────
+
+func TestInvalidJWTReturns401(t *testing.T) {
+	upstreamReached := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamReached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	privKey := generateRSAKeyPair(t)
+	_, jwksURL := jwksServer(t, privKey)
+
+	const (
+		domain   = "auth.example.test"
+		issuer   = "https://" + domain + "/"
+		audience = "test-audience"
+		prefix   = "/api/auth"
+	)
+
+	authMw := buildAuthMiddlewareWithLocalJWKS(t, issuer, audience, jwksURL)
+	mux := buildJWTTestMux(t, upstream, prefix, authMw)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, prefix+"/profile", nil)
+	r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", "this.is.not.a.valid.jwt"))
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+	if upstreamReached {
+		t.Error("upstream should not be reached with an invalid JWT")
+	}
+}


### PR DESCRIPTION
 ## Summary

  - Adds production-grade hardening to the API gateway: circuit breaker per upstream (opens after 5 failures, half-open after 30s), graceful shutdown with a 10s drain window, custom HTTP transport with timeouts, and a health endpoint that probes each upstream
  - Adds unit tests for middleware (CORS, logging, rate limiter, request ID, security), proxy, and config packages, plus integration tests covering routing, auth, middleware chain, and the health endpoint
  - Adds a README documenting the gateway's architecture, route table, and setup guide