### PR TITLE
feat(api-gateway): health endpoints, JSON errors, CORS, startup order, and infra improvements

### DIFF
--- a/api-gateway/.env.example
+++ b/api-gateway/.env.example
@@ -2,6 +2,9 @@
 PORT="API gateway port e.g. 8080"
 ENVIRONMENT="Use 'production' or 'development'"
 
+# ────────────────────────────────────── WEB APP ───────────────────────────────────────
+ALLOWED_ORIGINS="Frontend origin e.g. http://localhost:3000"
+
 # ──────────────────────────────────── MICROSERVICES ───────────────────────────────────
 SERVICE_AUTH_URL="Auth Service URL e.g. http://auth-service:8000"
 SERVICE_CORE_URL="Core Service URL e.g. http://core-service:8001"

--- a/api-gateway/.env.example
+++ b/api-gateway/.env.example
@@ -10,7 +10,6 @@ SERVICE_AUTH_URL="Auth Service URL e.g. http://auth-service:8000"
 SERVICE_CORE_URL="Core Service URL e.g. http://core-service:8001"
 SERVICE_GAME_URL="Gamification Service URL e.g. http://gamification-service:8002"
 SERVICE_FORUM_URL="Forum Service URL e.g. http://forum-service:8003"
-SERVICE_PAYMENT_URL="Payment Service URL e.g. http://payment-service:8005"
 
 # ───────────────────────────────────────── Auth0 ──────────────────────────────────────
 AUTH0_DOMAIN="Auth0 Domain (without https://) https://manage.auth0.com → Applications → Settings e.g. something.us.auth0.com"

--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -10,40 +10,29 @@ Every request passes through this middleware chain before reaching an upstream s
 Client → Security → RequestID → Logging → CORS → RateLimit → Auth → ReverseProxy → Microservice
 ```
 
-| Middleware | What it does |
-| `/api/payments` | payment | `/api/payments/checkout` → `/checkout` |
-|---|---|
-| Security | Sets `X-Content-Type-Options`, `X-Frame-Options`, and HSTS (production only) |
-| RequestID | Generates or propagates `X-Request-ID` across request and response |
-| Logging | Logs method, path, status code, and duration after the request completes |
-| CORS | Sets CORS headers; short-circuits OPTIONS preflight with 204 |
-| RateLimit | Token bucket per IP — 10 req/s, burst of 20 |
-| Auth | Validates Auth0 JWT; sets `X-User-Sub` from claims for upstream use |
+| Middleware   | What it does                                                                    |
+|--------------|---------------------------------------------------------------------------------|
+| Security     | Sets `X-Content-Type-Options`, `X-Frame-Options`, and HSTS (production only)    |
+| RequestID    | Generates or propagates `X-Request-ID` across request and response              |
+| Logging      | Logs method, path, status code, and duration after the request completes        |
+| CORS         | Sets CORS headers; short-circuits OPTIONS preflight with 204                    |
+| RateLimit    | Token bucket per IP — 10 req/s, burst of 20                                     |
+| Auth         | Validates Auth0 JWT; sets `X-User-Sub` from claims for upstream use             |
 | ReverseProxy | Strips path prefix and forwards to the target service; includes circuit breaker |
-For public callbacks that should bypass Auth0 validation, add `auth_exempt_paths` to the route. Example:
-
-```json
-{
-  "path_prefix": "/api/payments",
-  "service_name": "payment",
-  "auth_exempt_paths": ["/webhook"]
-}
-```
 
 The circuit breaker per upstream opens after 5 consecutive 5xx responses and resets after 30 seconds.
 
 ## Route table
 
-| `SERVICE_PAYMENT_URL` | Yes | Base URL of the payment service |
 Defined in `config.json`. Path prefix is stripped before forwarding.
 
-| Path prefix | Service | Example |
-|---|---|---|
-| `/api/auth` | auth | `/api/auth/login` → `/login` |
-| `/api/core` | core | `/api/core/users` → `/users` |
-| `/api/forum` | forum | `/api/forum/posts` → `/posts` |
-| `/api/game` | game | `/api/game/scores` → `/scores` |
-| `/api/gamification` | game | `/api/gamification/points` → `/points` |
+| Path prefix         | Service | Example                                |
+|---------------------|---------|----------------------------------------|
+| `/api/auth`         | auth    | `/api/auth/login` → `/login`           |
+| `/api/core`         | core    | `/api/core/users` → `/users`           |
+| `/api/forum`        | forum   | `/api/forum/posts` → `/posts`          |
+| `/api/game`         | game    | `/api/game/scores` → `/scores`         |
+| `/api/gamification` | game    | `/api/gamification/points` → `/points` |
 
 ### Adding a new service
 
@@ -64,83 +53,16 @@ SERVICE_MYSERVICE_URL=http://my-service:8080
 
 ## Environment variables
 
-# API Gateway
-
-Go reverse-proxy gateway that routes external traffic to five internal microservices: `auth`, `core`, `forum`, `game`, and `payment`.
-
-## Architecture
-
-Every request passes through this middleware chain before reaching an upstream service:
-
-```
-Client → Security → RequestID → Logging → CORS → RateLimit → Auth → ReverseProxy → Microservice
-```
-
-| Middleware | What it does |
-|---|---|
-| Security | Sets `X-Content-Type-Options`, `X-Frame-Options`, and HSTS (production only) |
-| RequestID | Generates or propagates `X-Request-ID` across request and response |
-| Logging | Logs method, path, status code, and duration after the request completes |
-| CORS | Sets CORS headers; short-circuits OPTIONS preflight with 204 |
-| RateLimit | Token bucket per IP — 10 req/s, burst of 20 |
-| Auth | Validates Auth0 JWT; sets `X-User-Sub` from claims for upstream use |
-| ReverseProxy | Strips path prefix and forwards to the target service; includes circuit breaker |
-
-The circuit breaker per upstream opens after 5 consecutive 5xx responses and resets after 30 seconds.
-
-## Route table
-
-Defined in `config.json`. Path prefix is stripped before forwarding.
-
-| Path prefix | Service | Example |
-|---|---|---|
-| `/api/auth` | auth | `/api/auth/login` → `/login` |
-| `/api/core` | core | `/api/core/users` → `/users` |
-| `/api/forum` | forum | `/api/forum/posts` → `/posts` |
-| `/api/game` | game | `/api/game/scores` → `/scores` |
-| `/api/gamification` | game | `/api/gamification/points` → `/points` |
-| `/api/payments` | payment | `/api/payments/checkout` → `/checkout` |
-
-### Adding a new service
-
-Add an entry to `config.json`:
-
-```json
-{
-  "path_prefix": "/api/myservice",
-  "service_name": "myservice"
-}
-```
-
-For public callbacks that should bypass Auth0 validation, add `auth_exempt_paths` to the route. Example:
-
-```json
-{
-  "path_prefix": "/api/payments",
-  "service_name": "payment",
-  "auth_exempt_paths": ["/webhook"]
-}
-```
-
-Then add the corresponding URL to `.env`:
-
-```env
-SERVICE_MYSERVICE_URL=http://my-service:8080
-```
-
-## Environment variables
-
-| Variable | Required | Description |
-|---|---|---|
-| `PORT` | Yes | Port the gateway listens on (e.g. `8080`) |
-| `ENVIRONMENT` | Yes | `production` enables HSTS; any other value disables it |
-| `AUTH0_DOMAIN` | Yes | Auth0 domain without `https://` (e.g. `foo.us.auth0.com`) |
-| `AUTH0_AUDIENCE` | Yes | Auth0 API audience (e.g. `https://my-api.com`) |
-| `SERVICE_AUTH_URL` | Yes | Base URL of the auth service |
-| `SERVICE_CORE_URL` | Yes | Base URL of the core service |
-| `SERVICE_FORUM_URL` | Yes | Base URL of the forum service |
-| `SERVICE_GAME_URL` | Yes | Base URL of the game/gamification service |
-| `SERVICE_PAYMENT_URL` | Yes | Base URL of the payment service |
+| Variable            | Required | Description                                               |
+|---------------------|----------|-----------------------------------------------------------|
+| `PORT`              | Yes      | Port the gateway listens on (e.g. `8080`)                 |
+| `ENVIRONMENT`       | Yes      | `production` enables HSTS; any other value disables it    |
+| `AUTH0_DOMAIN`      | Yes      | Auth0 domain without `https://` (e.g. `foo.us.auth0.com`) |
+| `AUTH0_AUDIENCE`    | Yes      | Auth0 API audience (e.g. `https://my-api.com`)            |
+| `SERVICE_AUTH_URL`  | Yes      | Base URL of the auth service                              |
+| `SERVICE_CORE_URL`  | Yes      | Base URL of the core service                              |
+| `SERVICE_FORUM_URL` | Yes      | Base URL of the forum service                             |
+| `SERVICE_GAME_URL`  | Yes      | Base URL of the game/gamification service                 |
 
 ## Running locally
 

--- a/api-gateway/cmd/main.go
+++ b/api-gateway/cmd/main.go
@@ -74,7 +74,7 @@ func logInitialStatus(server *http.Server, cfg *config.GeneralConfig) {
 	log.Printf("  %-10s %-15s   %s  %21s", "SERVICE", "PATH", "TARGET", "HEALTH")
 	log.Printf("  %-10s %-15s   %s  %21s", "───────", "────", "──────", "──────")
 	for _, route := range cfg.Routes {
-		isHealthy := router.CheckService(route.TargetURL + "/health")
+		isHealthy, _ := router.CheckService(route.TargetURL + "/health")
 		status := "OK"
 		if !isHealthy {
 			status = "NOT OK"

--- a/api-gateway/cmd/main.go
+++ b/api-gateway/cmd/main.go
@@ -64,22 +64,16 @@ func main() {
 		log.Fatalf("forced shutdown: %v", err)
 	}
 	log.Println("server stopped")
-
 }
 
 func logInitialStatus(server *http.Server, cfg *config.GeneralConfig) {
 	log.Printf("────────────────────────────────────────────────────────────────")
 	log.Println("API Gateway listening on", server.Addr)
 	log.Println("Registered services:")
-	log.Printf("  %-10s %-15s   %s  %21s", "SERVICE", "PATH", "TARGET", "HEALTH")
-	log.Printf("  %-10s %-15s   %s  %21s", "───────", "────", "──────", "──────")
+	log.Printf("  %-10s %-15s   %s", "SERVICE", "PATH", "TARGET")
+	log.Printf("  %-10s %-15s   %s", "───────", "────", "──────")
 	for _, route := range cfg.Routes {
-		isHealthy, _ := router.CheckService(route.TargetURL + "/health")
-		status := "OK"
-		if !isHealthy {
-			status = "NOT OK"
-		}
-		log.Printf("  %-10s %-15s → %s  %s", route.ServiceName, route.PathPrefix, route.TargetURL, status)
+		log.Printf("  %-10s %-15s → %s", route.ServiceName, route.PathPrefix, route.TargetURL)
 	}
 	log.Printf("────────────────────────────────────────────────────────────────")
 }

--- a/api-gateway/cmd/main.go
+++ b/api-gateway/cmd/main.go
@@ -1,3 +1,4 @@
+// Command api-gateway is the entry point for the reverse-proxy gateway.
 package main
 
 import (
@@ -15,49 +16,43 @@ import (
 	"github.com/joho/godotenv"
 )
 
+const shutdownTimeout = 10 * time.Second
+
 func main() {
-	// Load .env file
-	err := godotenv.Load()
-	if err != nil {
+	if err := godotenv.Load(); err != nil {
 		log.Fatalf("error loading .env file: %v", err)
 	}
 
-	// Set configuration
 	cfg, err := config.Load("config.json")
 	if err != nil {
 		log.Fatalf("failed to load config file: %v", err)
 	}
 
-	// Set router
 	mux, err := router.New(cfg)
 	if err != nil {
 		log.Fatalf("failed to create router: %v", err)
 	}
 
-	// Set server with the mux provided by the router
 	server := &http.Server{
 		Addr:    ":" + cfg.Port,
 		Handler: mux,
 	}
 
-	// Create a context that is canceled by Ctrl+C or SIGTERM
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	// Start the server in a goroutine
 	go func() {
 		logInitialStatus(server, cfg)
+		// http.ErrServerClosed is the expected error after Shutdown.
 		if err = server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 			log.Fatalf("server failed: %v", err)
 		}
 	}()
 
-	// Wait until the stop signal
 	<-ctx.Done()
 	log.Println("shutting down gracefully...")
 
-	// 10 seconds left to complete pending requests
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 
 	if err := server.Shutdown(shutdownCtx); err != nil {

--- a/api-gateway/config.json
+++ b/api-gateway/config.json
@@ -9,11 +9,6 @@
       "service_name": "core"
     },
     {
-      "path_prefix": "/api/payments",
-      "service_name": "payment",
-      "auth_exempt_paths": ["/webhook"]
-    },
-    {
       "path_prefix": "/api/forum",
       "service_name": "forum"
     },

--- a/api-gateway/config/config.go
+++ b/api-gateway/config/config.go
@@ -21,10 +21,11 @@ type ServiceRoute struct {
 }
 
 type GeneralConfig struct {
-	Port        string         `json:"-"` // Populate at runtime
-	Environment string         `json:"-"` // Populate at runtime
-	Auth        AuthConfig     `json:"-"` // Populate at runtime
-	Routes      []ServiceRoute `json:"routes"`
+	Port           string         `json:"-"` // Populate at runtime
+	Environment    string         `json:"-"` // Populate at runtime
+	AllowedOrigins string         `json:"-"` // Populate at runtime
+	Auth           AuthConfig     `json:"-"` // Populate at runtime
+	Routes         []ServiceRoute `json:"routes"`
 }
 
 func (cfg *GeneralConfig) InProduction() bool {
@@ -69,6 +70,13 @@ func Load(path string) (*GeneralConfig, error) {
 	config.Auth = AuthConfig{
 		Audience: authAudience, Domain: authDomain,
 	}
+
+	// Add the allowed origins (for CORS)
+	allowedOrigins, err := getEnvVariable("ALLOWED_ORIGINS")
+	if err != nil {
+		return nil, err
+	}
+	config.AllowedOrigins = allowedOrigins
 
 	// Add routes URL
 	for i := range config.Routes {

--- a/api-gateway/config/config.go
+++ b/api-gateway/config/config.go
@@ -1,3 +1,5 @@
+// Package config loads gateway configuration from a JSON file and
+// environment variables, and merges them into a single GeneralConfig.
 package config
 
 import (
@@ -7,57 +9,62 @@ import (
 	"strings"
 )
 
+// AuthConfig holds the Auth0 parameters used by the JWT validator.
 type AuthConfig struct {
 	Audience string
 	Domain   string
 }
 
+// ServiceRoute describes a single upstream microservice route.
+// TargetURL is populated at load time from SERVICE_<NAME>_URL.
 type ServiceRoute struct {
 	PathPrefix  string `json:"path_prefix"`
 	ServiceName string `json:"service_name"`
-	TargetURL   string `json:"-"` // Populate at runtime
-
+	TargetURL   string `json:"-"`
 }
 
+// GeneralConfig is the fully resolved gateway configuration.
+// Fields tagged json:"-" come from environment variables, not the file.
 type GeneralConfig struct {
-	Port           string         `json:"-"` // Populate at runtime
-	Environment    string         `json:"-"` // Populate at runtime
-	AllowedOrigins string         `json:"-"` // Populate at runtime
-	Auth           AuthConfig     `json:"-"` // Populate at runtime
+	Port           string         `json:"-"`
+	Environment    string         `json:"-"`
+	AllowedOrigins string         `json:"-"`
+	Auth           AuthConfig     `json:"-"`
 	Routes         []ServiceRoute `json:"routes"`
 }
 
+// InProduction reports whether the gateway is running with ENVIRONMENT=production.
 func (cfg *GeneralConfig) InProduction() bool {
 	return cfg.Environment == "production"
 }
 
+// Load reads the JSON configuration at path and merges in the required
+// environment variables (PORT, ENVIRONMENT, AUTH0_AUDIENCE, AUTH0_DOMAIN,
+// ALLOWED_ORIGINS, and SERVICE_<NAME>_URL for each route). It returns an
+// error if any required variable is missing.
 func Load(path string) (*GeneralConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading config file %s: %w", path, err)
 	}
 
-	// Load config from JSON
 	var config GeneralConfig
 	if err := json.Unmarshal(data, &config); err != nil {
-		return nil, fmt.Errorf("setting config file %w", err)
+		return nil, fmt.Errorf("parsing config file: %w", err)
 	}
 
-	// Add port
 	port, err := getEnvVariable("PORT")
 	if err != nil {
 		return nil, err
 	}
 	config.Port = port
 
-	// Add environment
 	environment, err := getEnvVariable("ENVIRONMENT")
 	if err != nil {
 		return nil, err
 	}
 	config.Environment = environment
 
-	// Add auth info (domain and audience)
 	authAudience, err := getEnvVariable("AUTH0_AUDIENCE")
 	if err != nil {
 		return nil, err
@@ -67,17 +74,16 @@ func Load(path string) (*GeneralConfig, error) {
 		return nil, err
 	}
 	config.Auth = AuthConfig{
-		Audience: authAudience, Domain: authDomain,
+		Audience: authAudience,
+		Domain:   authDomain,
 	}
 
-	// Add the allowed origins (for CORS)
 	allowedOrigins, err := getEnvVariable("ALLOWED_ORIGINS")
 	if err != nil {
 		return nil, err
 	}
 	config.AllowedOrigins = allowedOrigins
 
-	// Add routes URL
 	for i := range config.Routes {
 		envKey := "SERVICE_" + strings.ToUpper(config.Routes[i].ServiceName) + "_URL"
 		envValue, err := getEnvVariable(envKey)

--- a/api-gateway/config/config.go
+++ b/api-gateway/config/config.go
@@ -13,10 +13,9 @@ type AuthConfig struct {
 }
 
 type ServiceRoute struct {
-	PathPrefix      string   `json:"path_prefix"`
-	ServiceName     string   `json:"service_name"`
-	AuthExemptPaths []string `json:"auth_exempt_paths,omitempty"`
-	TargetURL       string   `json:"-"` // Populate at runtime
+	PathPrefix  string `json:"path_prefix"`
+	ServiceName string `json:"service_name"`
+	TargetURL   string `json:"-"` // Populate at runtime
 
 }
 

--- a/api-gateway/config/config.go
+++ b/api-gateway/config/config.go
@@ -73,10 +73,11 @@ func Load(path string) (*GeneralConfig, error) {
 	// Add routes URL
 	for i := range config.Routes {
 		envKey := "SERVICE_" + strings.ToUpper(config.Routes[i].ServiceName) + "_URL"
-		config.Routes[i].TargetURL = os.Getenv(envKey)
-		if config.Routes[i].TargetURL == "" {
-			return nil, fmt.Errorf("missing env key %s for service name %s", envKey, config.Routes[i].ServiceName)
+		envValue, err := getEnvVariable(envKey)
+		if err != nil {
+			return nil, err
 		}
+		config.Routes[i].TargetURL = envValue
 	}
 	return &config, nil
 }

--- a/api-gateway/config/config_test.go
+++ b/api-gateway/config/config_test.go
@@ -24,6 +24,7 @@ func setRequiredEnvVars(t *testing.T) {
 	t.Setenv("ENVIRONMENT", "staging")
 	t.Setenv("AUTH0_AUDIENCE", "test-audience")
 	t.Setenv("AUTH0_DOMAIN", "test.auth0.com")
+	t.Setenv("ALLOWED_ORIGINS", "*")
 }
 
 // --- Load() ---
@@ -44,6 +45,9 @@ func TestLoad_ValidConfig(t *testing.T) {
 	}
 	if cfg.Environment != "staging" {
 		t.Errorf("Environment: want %q, got %q", "staging", cfg.Environment)
+	}
+	if cfg.AllowedOrigins != "*" {
+		t.Errorf("AllowedOrigins: want %q, got %q", "*", cfg.AllowedOrigins)
 	}
 	if cfg.Auth.Audience != "test-audience" {
 		t.Errorf("Auth.Audience: want %q, got %q", "test-audience", cfg.Auth.Audience)

--- a/api-gateway/internal/middleware/auth.go
+++ b/api-gateway/internal/middleware/auth.go
@@ -48,7 +48,7 @@ func Auth(cfg config.AuthConfig) (Middleware, error) {
 			slog.Error("JWT validation failed", "error", err, "path", r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
-			if err := json.NewEncoder(w).Encode("Failed to validate JWT"); err != nil {
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "Failed to validate JWT"}); err != nil {
 				slog.Error("failed to encode response", "error", err)
 			}
 		}),
@@ -68,7 +68,7 @@ func Auth(cfg config.AuthConfig) (Middleware, error) {
 				slog.Error("missing claims", "error", err)
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusInternalServerError)
-				if err := json.NewEncoder(w).Encode("Error during authentication"); err != nil {
+				if err := json.NewEncoder(w).Encode(map[string]string{"error": "Error during authentication"}); err != nil {
 					slog.Error("failed to encode response", "error", err)
 				}
 				return

--- a/api-gateway/internal/middleware/auth.go
+++ b/api-gateway/internal/middleware/auth.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"time"
@@ -18,6 +20,7 @@ func Auth(cfg config.AuthConfig) (Middleware, error) {
 		return nil, err
 	}
 
+	// Initialize JWKS provider
 	provider, err := jwks.NewCachingProvider(
 		jwks.WithIssuerURL(issuerURL),
 		jwks.WithCacheTTL(5*time.Minute),
@@ -26,32 +29,51 @@ func Auth(cfg config.AuthConfig) (Middleware, error) {
 		return nil, err
 	}
 
+	// Create validator
 	jwtValidator, err := validator.New(
-		validator.WithKeyFunc(provider.KeyFunc),
-		validator.WithAlgorithm(validator.RS256),
-		validator.WithIssuer(issuerURL.String()),
-		validator.WithAudience(cfg.Audience),
+		validator.WithKeyFunc(provider.KeyFunc),        // Provides public keys for RS256
+		validator.WithAlgorithm(validator.RS256),       // Algorithm (prevents confusion attacks)
+		validator.WithAllowedClockSkew(30*time.Second), // Allows 30s clock drift
+		validator.WithIssuer(issuerURL.String()),       // Validates 'iss' claim
+		validator.WithAudience(cfg.Audience),           // Validates 'aud' claim
 	)
 	if err != nil {
 		return nil, err
 	}
 
+	// Wraps it into an actual HTTP middleware with custom error handler
 	jwtMiddleware, err := jwtmiddleware.New(
 		jwtmiddleware.WithValidator(jwtValidator),
+		jwtmiddleware.WithErrorHandler(func(w http.ResponseWriter, r *http.Request, err error) {
+			slog.Error("JWT validation failed", "error", err, "path", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			if err := json.NewEncoder(w).Encode("Failed to validate JWT"); err != nil {
+				slog.Error("failed to encode response", "error", err)
+			}
+		}),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	return func(next http.Handler) http.Handler {
-		// CheckJWT valida el token y pone claims en el context
-		return jwtMiddleware.CheckJWT(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Extraer claims del context
-			claims, err := jwtmiddleware.GetClaims[*validator.ValidatedClaims](r.Context())
-			if err == nil {
-				r.Header.Set("X-User-Sub", claims.RegisteredClaims.Subject)
-			}
 
+		// CheckJWT extracts and validates the token, and put the validated claims
+		return jwtMiddleware.CheckJWT(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+			// Set the user-sub header from the claims
+			claims, err := jwtmiddleware.GetClaims[*validator.ValidatedClaims](r.Context())
+			if err != nil { // should never happen - CheckJWT guarantees claims are set
+				slog.Error("missing claims", "error", err)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				if err := json.NewEncoder(w).Encode("Error during authentication"); err != nil {
+					slog.Error("failed to encode response", "error", err)
+				}
+				return
+			}
+			r.Header.Set("X-User-Sub", claims.RegisteredClaims.Subject)
 			next.ServeHTTP(w, r)
 		}))
 	}, nil

--- a/api-gateway/internal/middleware/auth.go
+++ b/api-gateway/internal/middleware/auth.go
@@ -14,13 +14,16 @@ import (
 	"api-gateway/config"
 )
 
+// Auth returns a middleware that validates an Auth0-issued RS256 JWT
+// against cfg's issuer and audience, and forwards the token's subject
+// to upstream services in the X-User-Sub header. Requests with an
+// invalid or missing token are rejected with 401.
 func Auth(cfg config.AuthConfig) (Middleware, error) {
 	issuerURL, err := url.Parse("https://" + cfg.Domain + "/")
 	if err != nil {
 		return nil, err
 	}
 
-	// Initialize JWKS provider
 	provider, err := jwks.NewCachingProvider(
 		jwks.WithIssuerURL(issuerURL),
 		jwks.WithCacheTTL(5*time.Minute),
@@ -29,19 +32,17 @@ func Auth(cfg config.AuthConfig) (Middleware, error) {
 		return nil, err
 	}
 
-	// Create validator
 	jwtValidator, err := validator.New(
-		validator.WithKeyFunc(provider.KeyFunc),        // Provides public keys for RS256
-		validator.WithAlgorithm(validator.RS256),       // Algorithm (prevents confusion attacks)
-		validator.WithAllowedClockSkew(30*time.Second), // Allows 30s clock drift
-		validator.WithIssuer(issuerURL.String()),       // Validates 'iss' claim
-		validator.WithAudience(cfg.Audience),           // Validates 'aud' claim
+		validator.WithKeyFunc(provider.KeyFunc),
+		validator.WithAlgorithm(validator.RS256),
+		validator.WithAllowedClockSkew(30*time.Second),
+		validator.WithIssuer(issuerURL.String()),
+		validator.WithAudience(cfg.Audience),
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	// Wraps it into an actual HTTP middleware with custom error handler
 	jwtMiddleware, err := jwtmiddleware.New(
 		jwtmiddleware.WithValidator(jwtValidator),
 		jwtmiddleware.WithErrorHandler(func(w http.ResponseWriter, r *http.Request, err error) {
@@ -58,13 +59,10 @@ func Auth(cfg config.AuthConfig) (Middleware, error) {
 	}
 
 	return func(next http.Handler) http.Handler {
-
-		// CheckJWT extracts and validates the token, and put the validated claims
 		return jwtMiddleware.CheckJWT(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
-			// Set the user-sub header from the claims
 			claims, err := jwtmiddleware.GetClaims[*validator.ValidatedClaims](r.Context())
-			if err != nil { // should never happen - CheckJWT guarantees claims are set
+			if err != nil {
+				// CheckJWT should guarantee claims are present; fail closed if not.
 				slog.Error("missing claims", "error", err)
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusInternalServerError)

--- a/api-gateway/internal/middleware/chain.go
+++ b/api-gateway/internal/middleware/chain.go
@@ -1,9 +1,15 @@
+// Package middleware contains the gateway's HTTP middlewares and the
+// Chain combinator that wires them together.
 package middleware
 
 import "net/http"
 
+// Middleware wraps an http.Handler with additional behaviour.
 type Middleware func(handler http.Handler) http.Handler
 
+// Chain composes middlewares around handler so that middleware[0] is the
+// outermost wrapper: a request enters through middleware[0] and ends at
+// handler.
 func Chain(handler http.Handler, middleware ...Middleware) http.Handler {
 	for i := len(middleware) - 1; i >= 0; i-- {
 		handler = middleware[i](handler)

--- a/api-gateway/internal/middleware/cors.go
+++ b/api-gateway/internal/middleware/cors.go
@@ -1,6 +1,8 @@
 package middleware
 
-import "net/http"
+import (
+	"net/http"
+)
 
 func CORS(allowedOrigins string) Middleware {
 	return func(next http.Handler) http.Handler {
@@ -8,16 +10,17 @@ func CORS(allowedOrigins string) Middleware {
 
 			// Add CORS headers to all the answers
 			w.Header().Set("Access-Control-Allow-Origin", allowedOrigins)
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
-			w.Header().Set("Access-Control-Max-Age", "86400") // 24 hours
 
 			// If it is a preflight, do not make the rest of the calls
 			if r.Method == http.MethodOptions {
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+				w.Header().Set("Access-Control-Max-Age", "86400") // 24 hours
 				w.WriteHeader(http.StatusNoContent)
 				return
 			}
 
+			w.Header().Set("Access-Control-Expose-Headers", "X-Request-ID")
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/api-gateway/internal/middleware/cors.go
+++ b/api-gateway/internal/middleware/cors.go
@@ -4,18 +4,19 @@ import (
 	"net/http"
 )
 
+const preflightMaxAge = "86400" // 24h
+
+// CORS sets the CORS headers and short-circuits OPTIONS preflight
+// requests with 204 so they never reach upstream services.
 func CORS(allowedOrigins string) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
-			// Add CORS headers to all the answers
 			w.Header().Set("Access-Control-Allow-Origin", allowedOrigins)
 
-			// If it is a preflight, do not make the rest of the calls
 			if r.Method == http.MethodOptions {
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 				w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
-				w.Header().Set("Access-Control-Max-Age", "86400") // 24 hours
+				w.Header().Set("Access-Control-Max-Age", preflightMaxAge)
 				w.WriteHeader(http.StatusNoContent)
 				return
 			}

--- a/api-gateway/internal/middleware/cors_test.go
+++ b/api-gateway/internal/middleware/cors_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 )
 
-func TestCORS_SetsHeadersOnEveryRequest(t *testing.T) {
-	methods := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions}
+func TestCORS_SetsHeadersOnNonOptionsRequest(t *testing.T) {
+	methods := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete}
 	for _, method := range methods {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(method, "/", nil)
@@ -16,14 +16,42 @@ func TestCORS_SetsHeadersOnEveryRequest(t *testing.T) {
 		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
 			t.Errorf("method=%s: Access-Control-Allow-Origin = %q, want %q", method, got, "https://example.com")
 		}
-		if got := w.Header().Get("Access-Control-Allow-Methods"); got == "" {
+		if got := w.Header().Get("Access-Control-Allow-Methods"); got != "" {
+			t.Errorf("method=%s: Access-Control-Allow-Methods should be empty", method)
+		}
+		if got := w.Header().Get("Access-Control-Allow-Headers"); got != "" {
+			t.Errorf("method=%s: Access-Control-Allow-Headers should be empty", method)
+		}
+		if got := w.Header().Get("Access-Control-Max-Age"); got != "" {
+			t.Errorf("method=%s: Access-Control-Max-Age should be empty", method)
+		}
+		if got := w.Header().Get("Access-Control-Expose-Headers"); got != "X-Request-ID" {
+			t.Errorf("method=%s: Access-Control-Expose-Headers should not be empty", method)
+		}
+	}
+}
+
+func TestCORS_SetsHeadersOnOptionsRequest(t *testing.T) {
+	methods := []string{http.MethodOptions}
+	for _, method := range methods {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(method, "/", nil)
+		CORS("https://example.com")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(w, r)
+
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+			t.Errorf("method=%s: Access-Control-Allow-Origin = %q, want %q", method, got, "https://example.com")
+		}
+		if got := w.Header().Get("Access-Control-Allow-Methods"); got != "GET, POST, PUT, DELETE, OPTIONS" {
 			t.Errorf("method=%s: Access-Control-Allow-Methods should not be empty", method)
 		}
-		if got := w.Header().Get("Access-Control-Allow-Headers"); got == "" {
+		if got := w.Header().Get("Access-Control-Allow-Headers"); got != "Authorization, Content-Type" {
 			t.Errorf("method=%s: Access-Control-Allow-Headers should not be empty", method)
 		}
-		if got := w.Header().Get("Access-Control-Max-Age"); got == "" {
+		if got := w.Header().Get("Access-Control-Max-Age"); got != "86400" {
 			t.Errorf("method=%s: Access-Control-Max-Age should not be empty", method)
+		}
+		if got := w.Header().Get("Access-Control-Expose-Headers"); got == "X-Request-ID" {
+			t.Errorf("method=%s: Access-Control-Expose-Headers should empty", method)
 		}
 	}
 }

--- a/api-gateway/internal/middleware/logging.go
+++ b/api-gateway/internal/middleware/logging.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+// responseRecorder captures the status code written by the inner
+// handler so it can be logged after the handler returns.
 type responseRecorder struct {
 	http.ResponseWriter
 	statusCode int
@@ -16,6 +18,8 @@ func (rr *responseRecorder) WriteHeader(code int) {
 	rr.ResponseWriter.WriteHeader(code)
 }
 
+// Logging emits one structured log line per request including method,
+// path, status, duration, and request ID.
 func Logging(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -27,7 +31,6 @@ func Logging(next http.Handler) http.Handler {
 
 		next.ServeHTTP(rr, r)
 
-		// Structure logging
 		slog.Info(
 			"REQUEST",
 			"method", r.Method,

--- a/api-gateway/internal/middleware/rate_limit.go
+++ b/api-gateway/internal/middleware/rate_limit.go
@@ -11,7 +11,7 @@ import (
 type ipLimiter struct {
 	limiters map[string]*rate.Limiter
 	mu       sync.Mutex
-	rate     rate.Limit // how many tokens are added per second
+	rate     rate.Limit // how many tokens are added per second (float64)
 	burst    int        // maximum capacity of the bucket
 }
 

--- a/api-gateway/internal/middleware/rate_limit.go
+++ b/api-gateway/internal/middleware/rate_limit.go
@@ -8,11 +8,12 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// ipLimiter holds one token-bucket rate limiter per client IP.
 type ipLimiter struct {
 	limiters map[string]*rate.Limiter
 	mu       sync.Mutex
-	rate     rate.Limit // how many tokens are added per second (float64)
-	burst    int        // maximum capacity of the bucket
+	rate     rate.Limit
+	burst    int
 }
 
 func newIPLimiter(rps float64, burst int) *ipLimiter {
@@ -36,6 +37,9 @@ func (l *ipLimiter) getLimiter(ip string) *rate.Limiter {
 	return limiter
 }
 
+// RateLimit returns a middleware that throttles requests per client IP
+// using a token bucket of rps requests/second with the given burst
+// capacity. Requests over budget are rejected with 429.
 func RateLimit(rps float64, burst int) Middleware {
 	limiter := newIPLimiter(rps, burst)
 

--- a/api-gateway/internal/middleware/request_id.go
+++ b/api-gateway/internal/middleware/request_id.go
@@ -15,8 +15,8 @@ func RequestID(next http.Handler) http.Handler {
 		}
 
 		// Propagate it to the microservice and also add it to the response
-		w.Header().Set("X-Request-ID", id)
-		r.Header.Set("X-Request-ID", id)
+		w.Header().Set("X-Request-ID", id) // back to the client
+		r.Header.Set("X-Request-ID", id)   // forward to microservice
 
 		next.ServeHTTP(w, r)
 	})

--- a/api-gateway/internal/middleware/request_id.go
+++ b/api-gateway/internal/middleware/request_id.go
@@ -6,24 +6,28 @@ import (
 	"net/http"
 )
 
+const requestIDByteLen = 16 // 128 bits
+
+// RequestID propagates the X-Request-ID header end-to-end, generating
+// a new one when the incoming request does not already carry it. The
+// value is written to both the request (for upstream) and the response
+// (for the client).
 func RequestID(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Use X-Request-ID if available
 		id := r.Header.Get("X-Request-ID")
 		if id == "" {
 			id = generateID()
 		}
 
-		// Propagate it to the microservice and also add it to the response
-		w.Header().Set("X-Request-ID", id) // back to the client
-		r.Header.Set("X-Request-ID", id)   // forward to microservice
+		w.Header().Set("X-Request-ID", id)
+		r.Header.Set("X-Request-ID", id)
 
 		next.ServeHTTP(w, r)
 	})
 }
 
 func generateID() string {
-	bytes := make([]byte, 16)
+	bytes := make([]byte, requestIDByteLen)
 	rand.Read(bytes)
 	return hex.EncodeToString(bytes)
 }

--- a/api-gateway/internal/middleware/security.go
+++ b/api-gateway/internal/middleware/security.go
@@ -2,16 +2,18 @@ package middleware
 
 import "net/http"
 
+const hstsMaxAge = "max-age=63072000; includeSubDomains" // 2 years
+
+// Security sets defensive HTTP response headers: X-Content-Type-Options,
+// X-Frame-Options, and (in production) Strict-Transport-Security.
 func Security(inProduction bool) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
-			// Set important headers (?)
 			w.Header().Set("X-Content-Type-Options", "nosniff")
 			w.Header().Set("X-Frame-Options", "DENY")
 
 			if inProduction {
-				w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+				w.Header().Set("Strict-Transport-Security", hstsMaxAge)
 			}
 
 			next.ServeHTTP(w, r)

--- a/api-gateway/internal/proxy/circuit_breaker.go
+++ b/api-gateway/internal/proxy/circuit_breaker.go
@@ -5,14 +5,22 @@ import (
 	"time"
 )
 
+// State transitions:
+//
+//	closed   --failures >= maxFailures--> open
+//	open     --resetTimeout elapsed-----> halfOpen
+//	halfOpen --success------------------> closed
+//	halfOpen --failure------------------> open
 type state int
 
 const (
-	closed   state = iota // normal, requests pass
-	halfOpen              // testing if the microservice recovered
-	open                  // cut, request are not forwarded
+	closed   state = iota // requests pass through
+	halfOpen              // a single probe is allowed to test recovery
+	open                  // requests are rejected
 )
 
+// CircuitBreaker is a goroutine-safe breaker that trips after a
+// configurable number of consecutive failures.
 type CircuitBreaker struct {
 	mu           sync.Mutex
 	state        state
@@ -30,6 +38,9 @@ func newCircuitBreaker(maxFailures int, resetTimeout time.Duration) *CircuitBrea
 	}
 }
 
+// allow reports whether a request may be sent to the upstream. When the
+// breaker is open and the reset timeout has elapsed, the next caller is
+// promoted to a half-open probe.
 func (cb *CircuitBreaker) allow() bool {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
@@ -43,7 +54,7 @@ func (cb *CircuitBreaker) allow() bool {
 			return true
 		}
 	case halfOpen:
-		return false // another request is testing
+		return false
 	}
 	return false
 }

--- a/api-gateway/internal/proxy/circuit_breaker.go
+++ b/api-gateway/internal/proxy/circuit_breaker.go
@@ -22,7 +22,7 @@ type CircuitBreaker struct {
 	lastFailure  time.Time
 }
 
-func NewCircuitBreaker(maxFailures int, resetTimeout time.Duration) *CircuitBreaker {
+func newCircuitBreaker(maxFailures int, resetTimeout time.Duration) *CircuitBreaker {
 	return &CircuitBreaker{
 		state:        closed,
 		maxFailures:  maxFailures,

--- a/api-gateway/internal/proxy/circuit_breaker_test.go
+++ b/api-gateway/internal/proxy/circuit_breaker_test.go
@@ -6,14 +6,14 @@ import (
 )
 
 func TestCircuitBreaker_StartsClosedAndAllowsRequests(t *testing.T) {
-	cb := NewCircuitBreaker(3, time.Second)
+	cb := newCircuitBreaker(3, time.Second)
 	if !cb.allow() {
 		t.Error("new circuit breaker should be closed and allow requests")
 	}
 }
 
 func TestCircuitBreaker_OpensAfterMaxFailures(t *testing.T) {
-	cb := NewCircuitBreaker(3, time.Second)
+	cb := newCircuitBreaker(3, time.Second)
 	for i := 0; i < 3; i++ {
 		cb.recordFailure()
 	}
@@ -23,7 +23,7 @@ func TestCircuitBreaker_OpensAfterMaxFailures(t *testing.T) {
 }
 
 func TestCircuitBreaker_HalfOpenAfterResetTimeout(t *testing.T) {
-	cb := NewCircuitBreaker(1, 50*time.Millisecond)
+	cb := newCircuitBreaker(1, 50*time.Millisecond)
 	cb.recordFailure()
 
 	if cb.allow() {
@@ -38,7 +38,7 @@ func TestCircuitBreaker_HalfOpenAfterResetTimeout(t *testing.T) {
 }
 
 func TestCircuitBreaker_SuccessInHalfOpenResetsToClose(t *testing.T) {
-	cb := NewCircuitBreaker(1, 50*time.Millisecond)
+	cb := newCircuitBreaker(1, 50*time.Millisecond)
 	cb.recordFailure()
 	time.Sleep(60 * time.Millisecond)
 	cb.allow()
@@ -51,7 +51,7 @@ func TestCircuitBreaker_SuccessInHalfOpenResetsToClose(t *testing.T) {
 }
 
 func TestCircuitBreaker_FailureInHalfOpenGoesBackToOpen(t *testing.T) {
-	cb := NewCircuitBreaker(1, 50*time.Millisecond)
+	cb := newCircuitBreaker(1, 50*time.Millisecond)
 	cb.recordFailure()
 	time.Sleep(60 * time.Millisecond)
 	cb.allow()
@@ -64,7 +64,7 @@ func TestCircuitBreaker_FailureInHalfOpenGoesBackToOpen(t *testing.T) {
 }
 
 func TestCircuitBreaker_RecordSuccessResetFailureCount(t *testing.T) {
-	cb := NewCircuitBreaker(3, time.Second)
+	cb := newCircuitBreaker(3, time.Second)
 	cb.recordFailure()
 	cb.recordFailure()
 	cb.recordSuccess()
@@ -75,7 +75,7 @@ func TestCircuitBreaker_RecordSuccessResetFailureCount(t *testing.T) {
 }
 
 func TestCircuitBreaker_DoesNotOpenBeforeMaxFailures(t *testing.T) {
-	cb := NewCircuitBreaker(3, time.Second)
+	cb := newCircuitBreaker(3, time.Second)
 	cb.recordFailure()
 	cb.recordFailure()
 
@@ -85,7 +85,7 @@ func TestCircuitBreaker_DoesNotOpenBeforeMaxFailures(t *testing.T) {
 }
 
 func TestCircuitBreaker_HalfOpenBlocksSecondConcurrentRequest(t *testing.T) {
-	cb := NewCircuitBreaker(1, 50*time.Millisecond)
+	cb := newCircuitBreaker(1, 50*time.Millisecond)
 	cb.recordFailure()
 	time.Sleep(60 * time.Millisecond)
 

--- a/api-gateway/internal/proxy/proxy.go
+++ b/api-gateway/internal/proxy/proxy.go
@@ -56,7 +56,7 @@ func New(targetURL string, pathPrefix string) (http.Handler, error) {
 		},
 	}
 
-	cb := NewCircuitBreaker(5, 30*time.Second)
+	cb := newCircuitBreaker(5, 30*time.Second)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !cb.allow() {

--- a/api-gateway/internal/proxy/proxy.go
+++ b/api-gateway/internal/proxy/proxy.go
@@ -1,7 +1,9 @@
 package proxy
 
 import (
+	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -58,7 +60,11 @@ func New(targetURL string, pathPrefix string) (http.Handler, error) {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !cb.allow() {
-			http.Error(w, fmt.Sprintf("service %s is unavailable", target.Host), http.StatusServiceUnavailable)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			if err := json.NewEncoder(w).Encode(fmt.Sprintf("service %s is unavailable", target.Host)); err != nil {
+				slog.Error("failed to encode response", "error", err, "host", target.Host)
+			}
 			return
 		}
 

--- a/api-gateway/internal/proxy/proxy.go
+++ b/api-gateway/internal/proxy/proxy.go
@@ -1,3 +1,6 @@
+// Package proxy builds the per-route reverse-proxy handler that
+// forwards requests to an upstream microservice, with timeouts and a
+// circuit breaker.
 package proxy
 
 import (
@@ -12,6 +15,19 @@ import (
 	"time"
 )
 
+const (
+	dialTimeout           = 5 * time.Second
+	responseHeaderTimeout = 10 * time.Second
+	maxIdleConns          = 10
+	maxIdleConnsPerHost   = 5
+	idleConnTimeout       = 90 * time.Second
+
+	cbMaxFailures  = 5
+	cbResetTimeout = 30 * time.Second
+)
+
+// responseRecorder captures the upstream's status code so the proxy
+// handler can feed it into the circuit breaker.
 type responseRecorder struct {
 	http.ResponseWriter
 	statusCode int
@@ -22,6 +38,9 @@ func (rr *responseRecorder) WriteHeader(code int) {
 	rr.ResponseWriter.WriteHeader(code)
 }
 
+// New returns an http.Handler that reverse-proxies requests to targetURL,
+// stripping pathPrefix from the incoming path. Transport errors and
+// open-circuit rejections are returned as JSON 503 responses.
 func New(targetURL string, pathPrefix string) (http.Handler, error) {
 	target, err := url.Parse(targetURL)
 	if err != nil {
@@ -30,12 +49,12 @@ func New(targetURL string, pathPrefix string) (http.Handler, error) {
 
 	transport := &http.Transport{
 		DialContext: (&net.Dialer{
-			Timeout: 5 * time.Second, // Timeout for establishing the TCP connection
+			Timeout: dialTimeout,
 		}).DialContext,
-		ResponseHeaderTimeout: 10 * time.Second, // Timeout waiting for the first response
-		MaxIdleConns:          10,               // Maximum of IDLE connections
-		MaxIdleConnsPerHost:   5,
-		IdleConnTimeout:       90 * time.Second, // Close IDLE connections after 90 seconds
+		ResponseHeaderTimeout: responseHeaderTimeout,
+		MaxIdleConns:          maxIdleConns,
+		MaxIdleConnsPerHost:   maxIdleConnsPerHost,
+		IdleConnTimeout:       idleConnTimeout,
 	}
 
 	proxy := &httputil.ReverseProxy{
@@ -43,12 +62,10 @@ func New(targetURL string, pathPrefix string) (http.Handler, error) {
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			pr.SetURL(target)
 			pr.SetXForwarded()
-
-			// Remove original prefix
-			originalPath := pr.In.URL.Path
-			pr.Out.URL.Path = strings.TrimPrefix(originalPath, pathPrefix)
+			pr.Out.URL.Path = strings.TrimPrefix(pr.In.URL.Path, pathPrefix)
 		},
 		ModifyResponse: func(resp *http.Response) error {
+			// CORS is owned by the gateway; drop upstream duplicates.
 			resp.Header.Del("Access-Control-Allow-Origin")
 			resp.Header.Del("Access-Control-Allow-Methods")
 			resp.Header.Del("Access-Control-Allow-Headers")
@@ -59,7 +76,7 @@ func New(targetURL string, pathPrefix string) (http.Handler, error) {
 		},
 	}
 
-	cb := newCircuitBreaker(5, 30*time.Second)
+	cb := newCircuitBreaker(cbMaxFailures, cbResetTimeout)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !cb.allow() {
@@ -78,15 +95,13 @@ func New(targetURL string, pathPrefix string) (http.Handler, error) {
 		} else {
 			cb.recordSuccess()
 		}
-
 	}), nil
 }
 
 func writeError(w http.ResponseWriter, target *url.URL, err error) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusServiceUnavailable)
-	if err := json.NewEncoder(w).Encode(map[string]string{"error": err.Error()}); err != nil {
-		slog.Error("failed to encode response", "error", err, "host", target.Host)
+	if encErr := json.NewEncoder(w).Encode(map[string]string{"error": err.Error()}); encErr != nil {
+		slog.Error("failed to encode response", "error", encErr, "host", target.Host)
 	}
-	return
 }

--- a/api-gateway/internal/proxy/proxy.go
+++ b/api-gateway/internal/proxy/proxy.go
@@ -54,17 +54,16 @@ func New(targetURL string, pathPrefix string) (http.Handler, error) {
 			resp.Header.Del("Access-Control-Allow-Headers")
 			return nil
 		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			writeError(w, target, err)
+		},
 	}
 
 	cb := newCircuitBreaker(5, 30*time.Second)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !cb.allow() {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusServiceUnavailable)
-			if err := json.NewEncoder(w).Encode(fmt.Sprintf("service %s is unavailable", target.Host)); err != nil {
-				slog.Error("failed to encode response", "error", err, "host", target.Host)
-			}
+			writeError(w, target, fmt.Errorf("service %s is unavailable", target.Host))
 			return
 		}
 
@@ -81,4 +80,13 @@ func New(targetURL string, pathPrefix string) (http.Handler, error) {
 		}
 
 	}), nil
+}
+
+func writeError(w http.ResponseWriter, target *url.URL, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusServiceUnavailable)
+	if err := json.NewEncoder(w).Encode(map[string]string{"error": err.Error()}); err != nil {
+		slog.Error("failed to encode response", "error", err, "host", target.Host)
+	}
+	return
 }

--- a/api-gateway/internal/proxy/proxy_test.go
+++ b/api-gateway/internal/proxy/proxy_test.go
@@ -141,7 +141,7 @@ func TestNew_CircuitBreakerResetAfterTimeout(t *testing.T) {
 	// Because we are in the same package (package proxy) we can instantiate
 	// CircuitBreaker directly and verify its state machine independently of
 	// the HTTP layer.
-	cb := NewCircuitBreaker(5, 50*time.Millisecond)
+	cb := newCircuitBreaker(5, 50*time.Millisecond)
 
 	// Trip the breaker.
 	for i := 0; i < 5; i++ {

--- a/api-gateway/internal/router/router.go
+++ b/api-gateway/internal/router/router.go
@@ -26,7 +26,7 @@ func New(cfg *config.GeneralConfig) (*http.ServeMux, error) {
 		middleware.Security(cfg.InProduction()),
 		middleware.RequestID,
 		middleware.Logging,
-		middleware.CORS("http://localhost:3000"),
+		middleware.CORS(cfg.AllowedOrigins),
 		middleware.RateLimit(10, 20),
 	}
 	middlewaresWithAuth := append(baseMiddlewares, authMiddleware)

--- a/api-gateway/internal/router/router.go
+++ b/api-gateway/internal/router/router.go
@@ -1,3 +1,5 @@
+// Package router builds the gateway's http.ServeMux, registering one
+// reverse-proxy handler per configured route plus health and 404 handlers.
 package router
 
 import (
@@ -13,27 +15,33 @@ import (
 	"time"
 )
 
+const (
+	defaultRPS         = 10.0
+	defaultBurst       = 20
+	healthProbeTimeout = 2 * time.Second
+)
+
+// New builds the gateway's HTTP handler: a reverse proxy per route in
+// cfg.Routes (authenticated), plus /health, /health/detailed and a JSON
+// 404 fallback (all unauthenticated).
 func New(cfg *config.GeneralConfig) (*http.ServeMux, error) {
 	mux := http.NewServeMux()
 
-	// Create auth middleware
 	authMiddleware, err := middleware.Auth(cfg.Auth)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create auth middleware %w", err)
+		return nil, fmt.Errorf("failed to create auth middleware: %w", err)
 	}
 
-	// Middlewares
 	baseMiddlewares := []middleware.Middleware{
 		middleware.Security(cfg.InProduction()),
 		middleware.RequestID,
 		middleware.Logging,
 		middleware.CORS(cfg.AllowedOrigins),
-		middleware.RateLimit(10, 20),
+		middleware.RateLimit(defaultRPS, defaultBurst),
 	}
 	middlewaresWithAuth := append(baseMiddlewares, authMiddleware)
 	middlewaresWithoutAuth := baseMiddlewares
 
-	// Register a proxy for each route
 	for _, route := range cfg.Routes {
 		prx, err := proxy.New(route.TargetURL, route.PathPrefix)
 		if err != nil {
@@ -43,24 +51,23 @@ func New(cfg *config.GeneralConfig) (*http.ServeMux, error) {
 		mux.Handle(route.PathPrefix+"/", handler)
 	}
 
-	// General health check: only this api gateway
 	mux.Handle("GET /health", middleware.Chain(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}), middlewaresWithoutAuth...))
 
-	// Detailed health check: includes this api gateway and the microservices
 	detailedHealthHandler := middleware.Chain(getDetailedHealthHandler(cfg), middlewaresWithoutAuth...)
 	mux.Handle("GET /health/detailed", detailedHealthHandler)
 
-	// Add base handler for / , used when the given route does not match with any on the mux table
 	notFoundHandler := middleware.Chain(getNotFoundHandler(), middlewaresWithoutAuth...)
 	mux.Handle("/", notFoundHandler)
 
 	return mux, nil
 }
 
+// getDetailedHealthHandler probes every upstream's /health concurrently
+// and returns a JSON map of {service: "OK" | "NOT OK"}. Responds with
+// 503 if any probe fails.
 func getDetailedHealthHandler(cfg *config.GeneralConfig) http.Handler {
-	// General health check: includes this api gateway and the microservices
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		status := map[string]string{}
 		allHealthy := true
@@ -68,7 +75,6 @@ func getDetailedHealthHandler(cfg *config.GeneralConfig) http.Handler {
 		var mu sync.Mutex
 
 		for _, route := range cfg.Routes {
-
 			wg.Add(1)
 			go func(r config.ServiceRoute) {
 				defer wg.Done()
@@ -107,8 +113,10 @@ func getNotFoundHandler() http.Handler {
 	})
 }
 
+// checkService issues a short-timeout GET to a service's /health URL.
+// A service is considered healthy when the response status is below 500.
 func checkService(url string) (bool, string) {
-	client := &http.Client{Timeout: 2 * time.Second}
+	client := &http.Client{Timeout: healthProbeTimeout}
 	resp, err := client.Get(url)
 	if err != nil {
 		return false, err.Error()

--- a/api-gateway/internal/router/router.go
+++ b/api-gateway/internal/router/router.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"strings"
 	"time"
 )
 

--- a/api-gateway/internal/router/router.go
+++ b/api-gateway/internal/router/router.go
@@ -6,6 +6,7 @@ import (
 	"api-gateway/internal/proxy"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -60,10 +61,12 @@ func getHealthHandler(cfg *config.GeneralConfig) http.Handler {
 		allHealthy := true
 
 		for _, route := range cfg.Routes {
-			if CheckService(route.TargetURL + "/health") {
+			serviceOk, serviceError := CheckService(route.TargetURL + "/health")
+			if serviceOk {
 				status[route.ServiceName] = "OK"
 			} else {
 				status[route.ServiceName] = "NOT OK"
+				slog.Error("failed health check", "service", route.ServiceName, "error", serviceError)
 				allHealthy = false
 			}
 		}
@@ -88,13 +91,16 @@ func getNotFoundHandler() http.Handler {
 	})
 }
 
-func CheckService(url string) bool {
+func CheckService(url string) (bool, string) {
 	client := &http.Client{Timeout: 2 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {
-		return false
+		return false, err.Error()
 	}
 	defer resp.Body.Close()
-	return resp.StatusCode < 500
-
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		body = []byte("failed to read response body: " + err.Error())
+	}
+	return resp.StatusCode < 500, string(body)
 }

--- a/api-gateway/internal/router/router.go
+++ b/api-gateway/internal/router/router.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -42,9 +43,14 @@ func New(cfg *config.GeneralConfig) (*http.ServeMux, error) {
 		mux.Handle(route.PathPrefix+"/", handler)
 	}
 
-	// General health check: includes this api gateway and the microservices
-	healthProxy := middleware.Chain(getHealthHandler(cfg), middlewaresWithoutAuth...)
-	mux.Handle("GET /health", healthProxy)
+	// General health check: only this api gateway
+	mux.Handle("GET /health", middleware.Chain(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), middlewaresWithoutAuth...))
+
+	// Detailed health check: includes this api gateway and the microservices
+	detailedHealthHandler := middleware.Chain(getDetailedHealthHandler(cfg), middlewaresWithoutAuth...)
+	mux.Handle("GET /health/detailed", detailedHealthHandler)
 
 	// Add base handler for / , used when the given route does not match with any on the mux table
 	notFoundHandler := middleware.Chain(getNotFoundHandler(), middlewaresWithoutAuth...)
@@ -53,22 +59,33 @@ func New(cfg *config.GeneralConfig) (*http.ServeMux, error) {
 	return mux, nil
 }
 
-func getHealthHandler(cfg *config.GeneralConfig) http.Handler {
+func getDetailedHealthHandler(cfg *config.GeneralConfig) http.Handler {
 	// General health check: includes this api gateway and the microservices
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		status := map[string]string{}
 		allHealthy := true
+		var wg sync.WaitGroup
+		var mu sync.Mutex
 
 		for _, route := range cfg.Routes {
-			serviceOk, serviceError := CheckService(route.TargetURL + "/health")
-			if serviceOk {
-				status[route.ServiceName] = "OK"
-			} else {
-				status[route.ServiceName] = "NOT OK"
-				slog.Error("failed health check", "service", route.ServiceName, "error", serviceError)
-				allHealthy = false
-			}
+
+			wg.Add(1)
+			go func(r config.ServiceRoute) {
+				defer wg.Done()
+				serviceOk, serviceError := checkService(r.TargetURL + "/health")
+				mu.Lock()
+				defer mu.Unlock()
+
+				if serviceOk {
+					status[r.ServiceName] = "OK"
+				} else {
+					status[r.ServiceName] = "NOT OK"
+					slog.Error("failed health check", "service", r.ServiceName, "error", serviceError)
+					allHealthy = false
+				}
+			}(route)
 		}
+		wg.Wait()
 
 		w.Header().Set("Content-Type", "application/json")
 		if !allHealthy {
@@ -84,13 +101,13 @@ func getNotFoundHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		if err := json.NewEncoder(w).Encode("Not found"); err != nil {
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Not found"}); err != nil {
 			slog.Error("failed to encode response", "error", err)
 		}
 	})
 }
 
-func CheckService(url string) (bool, string) {
+func checkService(url string) (bool, string) {
 	client := &http.Client{Timeout: 2 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {

--- a/api-gateway/internal/router/router.go
+++ b/api-gateway/internal/router/router.go
@@ -6,6 +6,7 @@ import (
 	"api-gateway/internal/proxy"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -14,8 +15,47 @@ import (
 func New(cfg *config.GeneralConfig) (*http.ServeMux, error) {
 	mux := http.NewServeMux()
 
+	// Create auth middleware
+	authMiddleware, err := middleware.Auth(cfg.Auth)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create auth middleware %w", err)
+	}
+
+	// Middlewares
+	baseMiddlewares := []middleware.Middleware{
+		middleware.Security(cfg.InProduction()),
+		middleware.RequestID,
+		middleware.Logging,
+		middleware.CORS("http://localhost:3000"),
+		middleware.RateLimit(10, 20),
+	}
+	middlewaresWithAuth := append(baseMiddlewares, authMiddleware)
+	middlewaresWithoutAuth := baseMiddlewares
+
+	// Register a proxy for each route
+	for _, route := range cfg.Routes {
+		prx, err := proxy.New(route.TargetURL, route.PathPrefix)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create proxy for %s: %w", route.PathPrefix, err)
+		}
+		handler := middleware.Chain(prx, middlewaresWithAuth...)
+		mux.Handle(route.PathPrefix+"/", handler)
+	}
+
 	// General health check: includes this api gateway and the microservices
-	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+	healthProxy := middleware.Chain(getHealthHandler(cfg), middlewaresWithoutAuth...)
+	mux.Handle("GET /health", healthProxy)
+
+	// Add base handler for / , used when the given route does not match with any on the mux table
+	notFoundHandler := middleware.Chain(getNotFoundHandler(), middlewaresWithoutAuth...)
+	mux.Handle("/", notFoundHandler)
+
+	return mux, nil
+}
+
+func getHealthHandler(cfg *config.GeneralConfig) http.Handler {
+	// General health check: includes this api gateway and the microservices
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		status := map[string]string{}
 		allHealthy := true
 
@@ -32,55 +72,20 @@ func New(cfg *config.GeneralConfig) (*http.ServeMux, error) {
 		if !allHealthy {
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}
-		json.NewEncoder(w).Encode(status)
-	})
-
-	// Create auth middleware
-	authMiddleware, err := middleware.Auth(cfg.Auth)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create auth middleware %w", err)
-	}
-
-	// Middlewares
-	baseMiddlewares := []middleware.Middleware{
-		middleware.Security(cfg.InProduction()),
-		middleware.RequestID,
-		middleware.Logging,
-		middleware.CORS("http://localhost:3000"),
-		middleware.RateLimit(10, 20),
-	}
-
-	// Register a proxy for each route
-	for _, route := range cfg.Routes {
-		prx, err := proxy.New(route.TargetURL, route.PathPrefix)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create proxy for %s: %w", route.PathPrefix, err)
+		if err := json.NewEncoder(w).Encode(status); err != nil {
+			slog.Error("failed to encode response", "error", err)
 		}
-
-		authMiddlewares := append(append([]middleware.Middleware{}, baseMiddlewares...), authMiddleware)
-		handlerWithAuth := middleware.Chain(prx, authMiddlewares...)
-		handlerWithoutAuth := middleware.Chain(prx, baseMiddlewares...)
-
-		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if isAuthExempt(route, r.URL.Path) {
-				handlerWithoutAuth.ServeHTTP(w, r)
-				return
-			}
-			handlerWithAuth.ServeHTTP(w, r)
-		})
-		mux.Handle(route.PathPrefix+"/", handler)
-	}
-
-	return mux, nil
+	})
 }
 
-func isAuthExempt(route config.ServiceRoute, requestPath string) bool {
-	for _, exemptPath := range route.AuthExemptPaths {
-		if requestPath == route.PathPrefix+exemptPath || strings.HasPrefix(requestPath, route.PathPrefix+exemptPath+"/") {
-			return true
+func getNotFoundHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		if err := json.NewEncoder(w).Encode("Not found"); err != nil {
+			slog.Error("failed to encode response", "error", err)
 		}
-	}
-	return false
+	})
 }
 
 func CheckService(url string) bool {

--- a/api-gateway/internal/router/router_integration_test.go
+++ b/api-gateway/internal/router/router_integration_test.go
@@ -77,9 +77,26 @@ func fakeUpstream(t *testing.T, statusCode int, receivedPath *string) *httptest.
 	}))
 }
 
-// ── Test 1: Health endpoint – all upstreams healthy ───────────────────────────
+// ── Test 1: Simple health endpoint – gateway liveness ─────────────────────────
 
-func TestHealthAllHealthy(t *testing.T) {
+// The /health endpoint is a gateway-only liveness probe: no upstream calls,
+// no auth required, just confirms the gateway process can serve requests.
+// It must work even when no routes are configured.
+func TestSimpleHealthReturns200WithoutAuth(t *testing.T) {
+	mux := newHealthOnlyMux(t, nil)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/health", nil)
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+// ── Test 2: Detailed health endpoint – all upstreams healthy ──────────────────
+
+func TestDetailedHealthAllHealthy(t *testing.T) {
 	svcA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -97,7 +114,7 @@ func TestHealthAllHealthy(t *testing.T) {
 	mux := newHealthOnlyMux(t, routes)
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodGet, "/health", nil)
+	r := httptest.NewRequest(http.MethodGet, "/health/detailed", nil)
 	mux.ServeHTTP(w, r)
 
 	if w.Code != http.StatusOK {
@@ -115,9 +132,9 @@ func TestHealthAllHealthy(t *testing.T) {
 	}
 }
 
-// ── Test 2: Health endpoint – one upstream unhealthy ──────────────────────────
+// ── Test 3: Detailed health endpoint – one upstream unhealthy ─────────────────
 
-func TestHealthOneUnhealthy(t *testing.T) {
+func TestDetailedHealthOneUnhealthy(t *testing.T) {
 	svcOK := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -135,7 +152,7 @@ func TestHealthOneUnhealthy(t *testing.T) {
 	mux := newHealthOnlyMux(t, routes)
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodGet, "/health", nil)
+	r := httptest.NewRequest(http.MethodGet, "/health/detailed", nil)
 	mux.ServeHTTP(w, r)
 
 	if w.Code != http.StatusServiceUnavailable {
@@ -154,7 +171,7 @@ func TestHealthOneUnhealthy(t *testing.T) {
 	}
 }
 
-// ── Test 3: CORS preflight short-circuits before auth ─────────────────────────
+// ── Test 4: CORS preflight short-circuits before auth ─────────────────────────
 
 func TestCORSPreflightShortCircuitsBeforeAuth(t *testing.T) {
 	upstreamReached := false
@@ -182,7 +199,7 @@ func TestCORSPreflightShortCircuitsBeforeAuth(t *testing.T) {
 	}
 }
 
-// ── Test 4: Security headers always present ───────────────────────────────────
+// ── Test 5: Security headers always present ───────────────────────────────────
 
 func TestSecurityHeadersAlwaysPresent(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -211,7 +228,7 @@ func TestSecurityHeadersAlwaysPresent(t *testing.T) {
 	}
 }
 
-// ── Test 5: Request-ID generated when absent ──────────────────────────────────
+// ── Test 6: Request-ID generated when absent ──────────────────────────────────
 
 func TestRequestIDGeneratedWhenAbsent(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -236,7 +253,7 @@ func TestRequestIDGeneratedWhenAbsent(t *testing.T) {
 	}
 }
 
-// ── Test 6: Request-ID propagated when present ────────────────────────────────
+// ── Test 7: Request-ID propagated when present ────────────────────────────────
 
 func TestRequestIDPropagatedWhenPresent(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -260,7 +277,7 @@ func TestRequestIDPropagatedWhenPresent(t *testing.T) {
 	}
 }
 
-// ── Test 7: Rate limiting returns 429 after burst ─────────────────────────────
+// ── Test 8: Rate limiting returns 429 after burst ─────────────────────────────
 
 func TestRateLimitReturns429AfterBurst(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -488,7 +505,7 @@ func buildJWTTestMux(
 	return mux
 }
 
-// ── Test 8: Valid JWT routes request to upstream with prefix stripped ──────────
+// ── Test 9: Valid JWT routes request to upstream with prefix stripped ──────────
 
 func TestValidJWTRoutesToUpstreamWithPrefixStripped(t *testing.T) {
 	var receivedPath string
@@ -529,7 +546,7 @@ func TestValidJWTRoutesToUpstreamWithPrefixStripped(t *testing.T) {
 	}
 }
 
-// ── Test 9: Invalid JWT returns 401 ───────────────────────────────────────────
+// ── Test 10: Invalid JWT returns 401 ──────────────────────────────────────────
 
 func TestInvalidJWTReturns401(t *testing.T) {
 	upstreamReached := false
@@ -562,5 +579,42 @@ func TestInvalidJWTReturns401(t *testing.T) {
 	}
 	if upstreamReached {
 		t.Error("upstream should not be reached with an invalid JWT")
+	}
+}
+
+// ── Test 11: Unknown routes fall through to the JSON 404 handler ──────────────
+
+// Verifies the mux wiring: any path that doesn't match a registered prefix
+// must be served by getNotFoundHandler() — not Go's default text/plain
+// "404 page not found" response — and must traverse the full middleware
+// chain without requiring auth.
+func TestUnknownRouteFallsThroughToNotFoundHandler(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	routes := []config.ServiceRoute{
+		{PathPrefix: "/api/auth", ServiceName: "auth", TargetURL: upstream.URL},
+	}
+	mux := newFullMux(t, routes)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/this/route/does/not/exist", nil)
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", got, "application/json")
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if got := body["error"]; got != "Not found" {
+		t.Errorf(`body["error"] = %q, want %q`, got, "Not found")
 	}
 }

--- a/api-gateway/internal/router/router_integration_test.go
+++ b/api-gateway/internal/router/router_integration_test.go
@@ -182,31 +182,6 @@ func TestCORSPreflightShortCircuitsBeforeAuth(t *testing.T) {
 	}
 }
 
-func TestAuthExemptPathBypassesAuth(t *testing.T) {
-	upstreamReached := false
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		upstreamReached = true
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer upstream.Close()
-
-	routes := []config.ServiceRoute{
-		{PathPrefix: "/api/payments", ServiceName: "payment", TargetURL: upstream.URL, AuthExemptPaths: []string{"/webhook"}},
-	}
-	mux := newFullMux(t, routes)
-
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodPost, "/api/payments/webhook", strings.NewReader(`{"data":{"id":"123"}}`))
-	mux.ServeHTTP(w, r)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200 from webhook path, got %d", w.Code)
-	}
-	if !upstreamReached {
-		t.Error("upstream should have been reached for the auth-exempt webhook path")
-	}
-}
-
 // ── Test 4: Security headers always present ───────────────────────────────────
 
 func TestSecurityHeadersAlwaysPresent(t *testing.T) {

--- a/api-gateway/internal/router/router_test.go
+++ b/api-gateway/internal/router/router_test.go
@@ -1,0 +1,277 @@
+package router
+
+import (
+	"api-gateway/config"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── getNotFoundHandler ────────────────────────────────────────────────────────
+
+func TestNotFoundHandler_Returns404(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/does/not/exist", nil)
+
+	getNotFoundHandler().ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestNotFoundHandler_SetsJSONContentType(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+
+	getNotFoundHandler().ServeHTTP(w, r)
+
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", got, "application/json")
+	}
+}
+
+func TestNotFoundHandler_ReturnsJSONEncodedBody(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+
+	getNotFoundHandler().ServeHTTP(w, r)
+
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if got := body["error"]; got != "Not found" {
+		t.Errorf(`body["error"] = %q, want %q`, got, "Not found")
+	}
+}
+
+func TestNotFoundHandler_HandlesAllMethods(t *testing.T) {
+	methods := []string{
+		http.MethodGet, http.MethodPost, http.MethodPut,
+		http.MethodDelete, http.MethodPatch, http.MethodHead,
+	}
+	for _, method := range methods {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(method, "/unknown", nil)
+
+		getNotFoundHandler().ServeHTTP(w, r)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("method=%s: status = %d, want %d", method, w.Code, http.StatusNotFound)
+		}
+	}
+}
+
+// ── getDetailedHealthHandler ──────────────────────────────────────────────────
+
+func TestDetailedHealthHandler_SetsJSONContentType(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.GeneralConfig{
+		Routes: []config.ServiceRoute{
+			{PathPrefix: "/api/svc", ServiceName: "svc", TargetURL: upstream.URL},
+		},
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/health/detailed", nil)
+
+	getDetailedHealthHandler(cfg).ServeHTTP(w, r)
+
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", got, "application/json")
+	}
+}
+
+// With no routes configured, the gateway itself is up and there are no
+// upstreams to fail, so the handler should return 200 with an empty JSON map.
+func TestDetailedHealthHandler_NoRoutesReturns200AndEmptyMap(t *testing.T) {
+	cfg := &config.GeneralConfig{Routes: nil}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/health/detailed", nil)
+
+	getDetailedHealthHandler(cfg).ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if len(body) != 0 {
+		t.Errorf("body = %v, want empty map", body)
+	}
+}
+
+// Distinct from the existing "upstream returns 5xx" test: here the upstream
+// is completely unreachable (server closed). checkService should fail with a
+// transport error, the service must be reported NOT OK, and the overall
+// response must be 503.
+func TestDetailedHealthHandler_UnreachableServiceReports503AndNotOK(t *testing.T) {
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := dead.URL
+	dead.Close() // shut it down so connections fail at the TCP layer
+
+	cfg := &config.GeneralConfig{
+		Routes: []config.ServiceRoute{
+			{PathPrefix: "/api/dead", ServiceName: "dead", TargetURL: deadURL},
+		},
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/health/detailed", nil)
+
+	getDetailedHealthHandler(cfg).ServeHTTP(w, r)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if got := body["dead"]; got != "NOT OK" {
+		t.Errorf("service dead: got %q, want %q", got, "NOT OK")
+	}
+}
+
+// Mixed scenario: one healthy upstream and one unreachable upstream. The
+// healthy service must be reported OK, the dead one NOT OK, and the overall
+// status code must be 503 because not all services are healthy.
+//
+// Also exercises the concurrent fan-out: with two services checked in
+// parallel, the WaitGroup + Mutex must produce a deterministic map.
+func TestDetailedHealthHandler_MixedHealthyAndUnreachable(t *testing.T) {
+	good := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer good.Close()
+
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := dead.URL
+	dead.Close()
+
+	cfg := &config.GeneralConfig{
+		Routes: []config.ServiceRoute{
+			{PathPrefix: "/api/good", ServiceName: "good", TargetURL: good.URL},
+			{PathPrefix: "/api/dead", ServiceName: "dead", TargetURL: deadURL},
+		},
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/health/detailed", nil)
+
+	getDetailedHealthHandler(cfg).ServeHTTP(w, r)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if got := body["good"]; got != "OK" {
+		t.Errorf("service good: got %q, want %q", got, "OK")
+	}
+	if got := body["dead"]; got != "NOT OK" {
+		t.Errorf("service dead: got %q, want %q", got, "NOT OK")
+	}
+}
+
+// The handler must hit each upstream at its /health subpath, not the bare
+// TargetURL — that's the contract checkService relies on.
+func TestDetailedHealthHandler_CallsUpstreamHealthSubpath(t *testing.T) {
+	var receivedPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.GeneralConfig{
+		Routes: []config.ServiceRoute{
+			{PathPrefix: "/api/svc", ServiceName: "svc", TargetURL: upstream.URL},
+		},
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/health/detailed", nil)
+
+	getDetailedHealthHandler(cfg).ServeHTTP(w, r)
+
+	if !strings.HasSuffix(receivedPath, "/health") {
+		t.Errorf("upstream received path = %q, want suffix %q", receivedPath, "/health")
+	}
+}
+
+// The concurrent fan-out should check services in parallel: total elapsed
+// time must be close to the slowest upstream, not the sum of all upstream
+// delays. With 3 services each sleeping 200ms, a sequential implementation
+// would take ~600ms; the concurrent one should finish in ~200ms.
+func TestDetailedHealthHandler_ChecksUpstreamsConcurrently(t *testing.T) {
+	const (
+		perServiceDelay = 200 * time.Millisecond
+		serviceCount    = 3
+		// Generous upper bound to avoid flakiness on a slow CI runner,
+		// but still well under the sequential lower bound of 600ms.
+		concurrentBudget = 450 * time.Millisecond
+	)
+
+	mkSlowUpstream := func() *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(perServiceDelay)
+			w.WriteHeader(http.StatusOK)
+		}))
+	}
+
+	servers := make([]*httptest.Server, 0, serviceCount)
+	routes := make([]config.ServiceRoute, 0, serviceCount)
+	for i := 0; i < serviceCount; i++ {
+		srv := mkSlowUpstream()
+		defer srv.Close()
+		servers = append(servers, srv)
+		routes = append(routes, config.ServiceRoute{
+			PathPrefix:  fmt.Sprintf("/api/svc%d", i),
+			ServiceName: fmt.Sprintf("svc%d", i),
+			TargetURL:   srv.URL,
+		})
+	}
+
+	cfg := &config.GeneralConfig{Routes: routes}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/health/detailed", nil)
+
+	start := time.Now()
+	getDetailedHealthHandler(cfg).ServeHTTP(w, r)
+	elapsed := time.Since(start)
+
+	if elapsed >= concurrentBudget {
+		t.Errorf("handler took %v with %d services × %v delay; expected < %v (sequential would be ~%v)",
+			elapsed, serviceCount, perServiceDelay, concurrentBudget, perServiceDelay*serviceCount)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	for i := 0; i < serviceCount; i++ {
+		name := fmt.Sprintf("svc%d", i)
+		if got := body[name]; got != "OK" {
+			t.Errorf("service %s: got %q, want %q", name, got, "OK")
+		}
+	}
+}

--- a/core-service/app/main.py
+++ b/core-service/app/main.py
@@ -43,6 +43,11 @@ def get_app() -> FastAPI:
     app.include_router(translate.router)
     app.include_router(review_history.router)
     app.include_router(anki.router)
+
+    @app.get("/health", tags=["Health"])
+    async def health_check():
+        return {"status": "ok", "service": "core-service"}
+
     return app
 
 app = get_app()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,8 +122,9 @@ services:
       - "8080:8080"
     env_file:
       - ./api-gateway/.env
-   
     environment:
+      PORT: 8080
+      ALLOWED_ORIGINS: http://localhost:3000
       SERVICE_AUTH_URL: http://auth-service:8000
       SERVICE_CORE_URL: http://core-service:8000
       SERVICE_FORUM_URL: http://forum-service:8003
@@ -167,7 +168,6 @@ services:
       MONGO_URL: mongodb://mongo:27017
       MONGO_DB: core_db
       DEBUG: "true"
-      DEEPL_API_KEY: "dummy"
       LIBRETRANSLATE_URL: "https://libretranslate.com"
       RABBITMQ_URL: amqp://guest:guest@rabbitmq/
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,11 @@ services:
       - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U root"]
-      interval: 5s
+      start_period: 30s
+      start_interval: 2s
+      interval: 30s
       timeout: 3s
-      retries: 10
+      retries: 5
 
   mongo:
     container_name: mongo
@@ -26,8 +28,10 @@ services:
       - forum_mongo_database:/data/db
     healthcheck:
       test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
-      interval: 10s
-      timeout: 5s
+      start_period: 10s
+      start_interval: 2s
+      interval: 30s
+      timeout: 3s
       retries: 5
 
   redis:
@@ -37,7 +41,9 @@ services:
       - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
+      start_period: 10s
+      start_interval: 2s
+      interval: 30s
       timeout: 3s
       retries: 5
 
@@ -46,11 +52,13 @@ services:
     container_name: rabbitmq
     ports:
       - "5672:5672"
-      - "15672:15673"
+      - "15672:15672"
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "check_port_connectivity"]
-      interval: 5s
-      timeout: 5s
+      start_period: 10s
+      start_interval: 2s
+      interval: 30s
+      timeout: 3s
       retries: 5
 
   # ─── DB MIGRATIONS / SEEDERS ───────────────────────────────────────────────
@@ -82,8 +90,6 @@ services:
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: password
       POSTGRES_PORT: 5432
-      MONGO_URL: mongodb://mongo:27018
-      MONGO_DB: core_db
     depends_on:
       postgres:
         condition: service_healthy
@@ -130,6 +136,13 @@ services:
       SERVICE_FORUM_URL: http://forum-service:8003
       SERVICE_GAME_URL: http://gamification-service:8080
       SERVICE_PAYMENT_URL: http://payment-service:8005
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]
+      start_period: 10s
+      start_interval: 2s
+      interval: 30s
+      timeout: 3s
+      retries: 5
     depends_on:
       auth-service:
         condition: service_healthy
@@ -137,8 +150,6 @@ services:
         condition: service_healthy
       forum-service:
         condition: service_healthy
-#      gamification-service:
-#        condition: service_healthy
 
   # ─── BACKEND MICROSERVICES ──────────────────────────────────────────────────
   auth-service:
@@ -152,14 +163,15 @@ services:
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: password
       POSTGRES_PORT: 5432
+      DEBUG: "true"
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]  
-      interval: 5s
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      start_period: 10s
+      start_interval: 2s
+      interval: 30s
       timeout: 3s
       retries: 5
     depends_on:
-      postgres:
-        condition: service_healthy
       auth_migration:
         condition: service_completed_successfully
 
@@ -180,13 +192,13 @@ services:
       LIBRETRANSLATE_URL: "https://libretranslate.com"
       RABBITMQ_URL: amqp://guest:guest@rabbitmq/
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]  
-      interval: 5s
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      start_period: 10s
+      start_interval: 2s
+      interval: 30s
       timeout: 3s
       retries: 5
     depends_on:
-      postgres:
-        condition: service_healthy
       core_migration:
         condition: service_completed_successfully
 
@@ -200,35 +212,35 @@ services:
       ATLAS_PASS: dummy
       ATLAS_CLUSTER: dummy
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8003/health')"]  
-      interval: 5s
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8003/health')"]
+      start_period: 10s
+      start_interval: 2s
+      interval: 30s
       timeout: 3s
       retries: 5
     depends_on:
-      mongo:
-        condition: service_healthy
       forum_seed:
         condition: service_completed_successfully
 
-  payment-service:
-    build: ./payment-service
-    container_name: payment-service
-    env_file:
-      - ./payment-service/.env
-    environment:
-      DATABASE_URL: postgresql+asyncpg://root:password@postgres:5432/payment_db
-      # MERCADOPAGO_ACCESS_TOKEN, MERCADOPAGO_PUBLIC_KEY and JWT_SECRET are
-      # provided via the service env_file (payment-service/.env). Avoid using
-      # ${VAR} interpolation here so Compose does not require them in the host
-      # environment and the file values are used inside the container.
-      AUTH_SERVICE_URL: http://auth-service:8000
-    ports:
-      - "8005:8005"
-    depends_on:
-      postgres:
-        condition: service_healthy
-      payment_migration:
-        condition: service_completed_successfully
+#  payment-service:
+#    build: ./payment-service
+#    container_name: payment-service
+#    env_file:
+#      - ./payment-service/.env
+#    environment:
+#      DATABASE_URL: postgresql+asyncpg://root:password@postgres:5432/payment_db
+#      # MERCADOPAGO_ACCESS_TOKEN, MERCADOPAGO_PUBLIC_KEY and JWT_SECRET are
+#      # provided via the service env_file (payment-service/.env). Avoid using
+#      # ${VAR} interpolation here so Compose does not require them in the host
+#      # environment and the file values are used inside the container.
+#      AUTH_SERVICE_URL: http://auth-service:8000
+#    ports:
+#      - "8005:8005"
+#    depends_on:
+#      postgres:
+#        condition: service_healthy
+#      payment_migration:
+#        condition: service_completed_successfully
 
 #  gamification-service:
 #    build: ./gamification-service/GamificationService
@@ -273,8 +285,8 @@ services:
       SERVER_GAMIFICATION_URL: http://api-gateway:8080/api/gamification
       SERVER_PAYMENT_URL: http://api-gateway:8080/api/payments
     depends_on:
-      - api-gateway
-      - redis
+      api-gateway:
+        condition: service_healthy
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,10 +131,14 @@ services:
       SERVICE_GAME_URL: http://gamification-service:8080
       SERVICE_PAYMENT_URL: http://payment-service:8005
     depends_on:
-      - auth-service
-      - core-service
-      - forum-service
-#      - gamification-service
+      auth-service:
+        condition: service_healthy
+      core-service:
+        condition: service_healthy
+      forum-service:
+        condition: service_healthy
+#      gamification-service:
+#        condition: service_healthy
 
   # ─── BACKEND MICROSERVICES ──────────────────────────────────────────────────
   auth-service:
@@ -148,6 +152,11 @@ services:
       POSTGRES_HOST: postgres
       POSTGRES_PASSWORD: password
       POSTGRES_PORT: 5432
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]  
+      interval: 5s
+      timeout: 3s
+      retries: 5
     depends_on:
       postgres:
         condition: service_healthy
@@ -170,6 +179,11 @@ services:
       DEBUG: "true"
       LIBRETRANSLATE_URL: "https://libretranslate.com"
       RABBITMQ_URL: amqp://guest:guest@rabbitmq/
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]  
+      interval: 5s
+      timeout: 3s
+      retries: 5
     depends_on:
       postgres:
         condition: service_healthy
@@ -185,6 +199,11 @@ services:
       ATLAS_USER: dummy
       ATLAS_PASS: dummy
       ATLAS_CLUSTER: dummy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8003/health')"]  
+      interval: 5s
+      timeout: 3s
+      retries: 5
     depends_on:
       mongo:
         condition: service_healthy
@@ -228,8 +247,6 @@ services:
 #      redis:
 #        condition: service_healthy
 
-
-
   enrichment-service:
     build: ./enrichment-service
     container_name: enrichment-service
@@ -246,7 +263,6 @@ services:
     container_name: web-app
     ports:
       - "3000:3000"
-  
     env_file: ./web-app/parla/.env
     environment:
       SERVER_AUTH_URL: http://api-gateway:8080/api/auth
@@ -259,6 +275,7 @@ services:
     depends_on:
       - api-gateway
       - redis
+
 volumes:
   postgres_data:
   forum_mongo_database:


### PR DESCRIPTION
  ## Summary
   - Split `/health` into a liveness probe (`/live`) and a detailed health check with parallel polling per service; make both endpoints public and add a JSON 404 fallback route
   - Propagate per-service health check errors to structured logs with the full response body
   - Standardize all error responses to a consistent JSON object shape (circuit breaker, JWT errors, clock skew tolerance)
   - Configure CORS allowed origins from env and improve preflight handling
   - Add Godoc comments and extract magic numbers into named constants
   - Refactor: unexport `CircuitBreaker` constructor, extract env variable lookup into a helper function
   - Enforce Docker startup order with healthchecks on auth, core, and forum services; tune healthcheck intervals and add api-gateway liveness probe; fix RabbitMQ port mapping
   - Revert unintended api-gateway changes accidentally introduced in d72c59c2
   - Update and expand tests for health endpoints, CORS, config, and 404 handler